### PR TITLE
Simplify core.op_arg initialisation

### DIFF
--- a/pyop2/runtime_base.py
+++ b/pyop2/runtime_base.py
@@ -54,8 +54,7 @@ class Arg(base.Arg):
     @property
     def _c_handle(self):
         if self._lib_handle is None:
-            self._lib_handle = core.op_arg(self, dat=isinstance(self._dat, Dat),
-                                         gbl=isinstance(self._dat, Global))
+            self._lib_handle = core.op_arg(self)
         return self._lib_handle
 
 class Set(base.Set):


### PR DESCRIPTION
Since the great class hierarchy reordering, the file defining the base
pyop2 classes no longer imports op_lib_core.  So we can happily import
base into op_lib_core and use isinstance(arg.data, base.Dat) to
determine if this arg is actually a Dat or a Global when instantiating
the C level op_arg.
