### PR TITLE
Allow python GC to clean up core op_mat objects

### DIFF
--- a/pyop2/_op_lib_core.pxd
+++ b/pyop2/_op_lib_core.pxd
@@ -107,6 +107,8 @@ cdef extern from "op_lib_mat.h":
 
     op_mat op_decl_mat(op_sparsity, int *, int, char *, int, char *)
 
+    void op_mat_destroy(op_mat)
+
     void op_mat_get_values ( op_mat mat, double **v, int *m, int *n)
 
     void op_mat_zero_rows ( op_mat mat, int n, int *rows, double val)

--- a/pyop2/op_lib_core.pyx
+++ b/pyop2/op_lib_core.pyx
@@ -305,6 +305,10 @@ cdef class op_mat:
     def restore_array(self):
         core.op_mat_put_array(self._handle)
 
+    def __del__(self):
+        core.op_mat_destroy(self._handle)
+        self._handle = NULL
+
     @property
     def cptr(self):
         cdef uintptr_t val

--- a/pyop2/runtime_base.py
+++ b/pyop2/runtime_base.py
@@ -178,3 +178,7 @@ class Mat(base.Mat):
         if self._lib_handle is None:
             self._lib_handle = core.op_mat(self)
         return self._lib_handle
+
+    def __del__(self):
+        self._lib_handle.__del__()
+        self._lib_handle = None


### PR DESCRIPTION
Add a `__del__` method to `runtime_base` and `op_lib_core` Mat objects.  The
former explicitly calls `__del__` on the latter which just destroys the
C level matrix object and sets the pointer to `NULL`, the `_lib_handle` is
then set to None.

This fixes memory leaks in the case where we do:

```
for i in range(...):
    mat = op2.Mat(...)
```
