### PR TITLE
Use maps from correct set in Weak BCs demo

### DIFF
--- a/demo/weak_bcs_ffc.py
+++ b/demo/weak_bcs_ffc.py
@@ -147,14 +147,14 @@ op2.par_loop(rhs, elements(3),
              b(elem_node[op2.i[0]], op2.INC),
              coords(elem_node, op2.READ),
              f(elem_node, op2.READ),
-             bdry_grad(top_bdry_elem_node, op2.READ)) # argument ignored
+             bdry_grad(elem_node, op2.READ)) # argument ignored
 
 # Apply weak BC
 
 op2.par_loop(weak, top_bdry_elements(3),
              b(top_bdry_elem_node[op2.i[0]], op2.INC),
              coords(top_bdry_elem_node, op2.READ),
-             f(elem_node, op2.READ), # argument ignored
+             f(top_bdry_elem_node, op2.READ), # argument ignored
              bdry_grad(top_bdry_elem_node, op2.READ),
              facet(op2.READ))
 


### PR DESCRIPTION
I think that there is actually an error in the weak BCs demo - the ignored arguments to each par_loop should be using the map from the iteration set to the nodes, which was not the case. 

flop.py will also always construct an argument list that always uses maps from the iteration set to the data set - this brings the weak BCs demo into line with that behaviour.
