### PR TITLE
Add installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,16 @@ $ fakeroot alien *.rpm
 $ sudo dpkg -i *.deb
 ```
 
-Installing the AMD OpenCL toolkit (32bit and 64bit systems)
+Installing the [AMD OpenCL toolkit](http://developer.amd.com/tools/heterogeneous-computing/amd-accelerated-parallel-processing-app-sdk/) (32bit and 64bit systems)
 
 ```
 $ wget http://developer.amd.com/Downloads/AMD-APP-SDK-v2.7-lnx64.tgz
-# on a 32bit system
+# on a 32bit system, instead
 # wget http://developer.amd.com/Downloads/AMD-APP-SDK-v2.7-lnx32.tgz
-$ tar xzf AMD-APP-SDK-v2.7-lnx64.tgz
+$ tar xzf AMD-APP-SDK-v2.7-lnx*.tgz
 # Install to /usr/local instead of /opt
-$ sed -ie 's:/opt:/usr/local:g'
+$ sed -ie 's:/opt:/usr/local:g' default-install_lnx.pl
+$ sudo ./Install-AMD-APP.sh
 ```
 
 ### HDF5


### PR DESCRIPTION
Add installation instructions in the README. Advantages:
1. The installation instructions show up on the PyOP2 repository page.
2. The instructions will be in sync with the changes that are made to the repo (as opposed to being separate on the wiki, where if dependencies have been added or removed it is harder to match up the instructions to a given revision).
