### PR TITLE
Return a list of Kernels corresponding to integrals.

### DIFF
--- a/demo/adv_diff.py
+++ b/demo/adv_diff.py
@@ -89,10 +89,10 @@ diff_rhs=action(M+0.5*d,t)
 
 # Generate code for mass and rhs assembly.
 
-mass, _, _        = compile_form(M,           "mass")
-adv_rhs, _, _     = compile_form(adv_rhs,     "adv_rhs")
-diff_matrix, _, _ = compile_form(diff_matrix, "diff_matrix")
-diff_rhs, _, _    = compile_form(diff_rhs,    "diff_rhs")
+mass,        = compile_form(M,           "mass")
+adv_rhs,     = compile_form(adv_rhs,     "adv_rhs")
+diff_matrix, = compile_form(diff_matrix, "diff_matrix")
+diff_rhs,    = compile_form(diff_rhs,    "diff_rhs")
 
 # Set up simulation data structures
 

--- a/demo/burgers.py
+++ b/demo/burgers.py
@@ -96,8 +96,8 @@ v = TestFunction(V)
 a = (dot(u,grad(u_next))*v + nu*grad(u_next)*grad(v))*dx
 L = v*u*dx
 
-burgers, _, _ = compile_form(a, "burgers")
-rhs, _, _ = compile_form(L, "rhs")
+burgers, = compile_form(a, "burgers")
+rhs, = compile_form(L, "rhs")
 
 # Initial condition
 

--- a/demo/laplace_ffc.py
+++ b/demo/laplace_ffc.py
@@ -77,8 +77,8 @@ L = v*f*dx
 
 # Generate code for Laplacian and rhs assembly.
 
-laplacian, _, _ = compile_form(a, "laplacian")
-rhs, _, _  = compile_form(L, "rhs")
+laplacian, = compile_form(a, "laplacian")
+rhs,  = compile_form(L, "rhs")
 
 # Set up simulation data structures
 
@@ -140,6 +140,7 @@ op2.par_loop(strongbc_rhs, bdry_nodes,
              b(bdry_node_node[0], op2.WRITE))
 
 solver = op2.Solver()
+solver.parameters['linear_solver'] = 'gmres'
 solver.solve(mat, x, b)
 
 # Print solution

--- a/demo/mass2d_ffc.py
+++ b/demo/mass2d_ffc.py
@@ -68,8 +68,8 @@ L = v*f*dx
 
 # Generate code for mass and rhs assembly.
 
-mass, _, _ = compile_form(a, "mass")
-rhs, _, _  = compile_form(L, "rhs")
+mass, = compile_form(a, "mass")
+rhs,  = compile_form(L, "rhs")
 
 # Set up simulation data structures
 

--- a/demo/mass2d_triangle.py
+++ b/demo/mass2d_triangle.py
@@ -72,8 +72,8 @@ L = v*f*dx
 
 # Generate code for mass and rhs assembly.
 
-mass, _, _ = compile_form(a, "mass")
-rhs, _, _  = compile_form(L, "rhs")
+mass, = compile_form(a, "mass")
+rhs,  = compile_form(L, "rhs")
 
 # Set up simulation data structures
 

--- a/demo/mass_vector_ffc.py
+++ b/demo/mass_vector_ffc.py
@@ -64,8 +64,8 @@ L = inner(v,f)*dx
 
 # Generate code for mass and rhs assembly.
 
-mass, _, _ = compile_form(a, "mass")
-rhs, _, _  = compile_form(L, "rhs")
+mass, = compile_form(a, "mass")
+rhs,  = compile_form(L, "rhs")
 
 # Set up simulation data structures
 

--- a/demo/weak_bcs_ffc.py
+++ b/demo/weak_bcs_ffc.py
@@ -72,12 +72,12 @@ f = Coefficient(E)
 g = Coefficient(E)
 
 a = dot(grad(v,),grad(u))*dx
-L = v*f*dx + v*g*ds
+L = v*f*dx + v*g*ds(2)
 
 # Generate code for Laplacian and rhs assembly.
 
-laplacian, _, _ = compile_form(a, "laplacian")
-rhs, _, weak  = compile_form(L, "rhs")
+laplacian, = compile_form(a, "laplacian")
+rhs, weak  = compile_form(L, "rhs")
 
 # Set up simulation data structures
 
@@ -169,6 +169,7 @@ op2.par_loop(strongbc_rhs, bdry_nodes,
              b(bdry_node_node[0], op2.WRITE))
 
 solver = op2.Solver()
+solver.parameters['linear_solver'] = 'gmres'
 solver.solve(mat, x, b)
 
 # Print solution

--- a/pyop2/ffc_interface.py
+++ b/pyop2/ffc_interface.py
@@ -70,15 +70,9 @@ def compile_form(form, name):
         code = ffc_compile_form(form, prefix=name, parameters=ffc_parameters)
         form_data = form.form_data()
 
-        # FIXME: This breaks if the form contains > 1 domain of a particular kind
-        cell = Kernel(code, name + '_cell_integral_0_0') \
-                if form_data.num_cell_domains > 0 else None
-        interior_facet = Kernel(code, name + '_interior_facet_integral_0_0') \
-                if form_data.num_interior_facet_domains > 0 else None
-        exterior_facet = Kernel(code, name + '_exterior_facet_integral_0_0') \
-                if form_data.num_exterior_facet_domains > 0 else None
-
-        kernels = (cell, interior_facet, exterior_facet)
+        kernels = [ Kernel(code, '%s_%s_integral_0_%s' % (name, m.domain_type(), m.domain_id())) \
+                    for m in map(lambda x: x.measure(), form.integrals()) ]
+        kernels = tuple(kernels)
         _form_cache[key] = kernels, form_data
 
     # Attach the form data FFC has computed for our form (saves preprocessing

--- a/test/unit/test_ffc_interface.py
+++ b/test/unit/test_ffc_interface.py
@@ -92,15 +92,15 @@ class TestFFCCache:
 
     def test_ffc_cell_kernel(self, backend, mass):
         k = ffc_interface.compile_form(mass, 'mass')
-        assert 'cell_integral' in k[0].code and k[1] is None and k[2] is None
+        assert 'cell_integral' in k[0].code and len(k) == 1
 
     def test_ffc_exterior_facet_kernel(self, backend, rhs):
         k = ffc_interface.compile_form(rhs, 'rhs')
-        assert 'exterior_facet_integral' in k[2].code and k[0] is None and k[1] is None
+        assert 'exterior_facet_integral' in k[0].code and len(k) == 1
 
     def test_ffc_cell_exterior_facet_kernel(self, backend, rhs2):
         k = ffc_interface.compile_form(rhs2, 'rhs2')
-        assert 'cell_integral' in k[0].code and 'exterior_facet_integral' in k[2].code and k[1] is None
+        assert 'cell_integral' in k[0].code and 'exterior_facet_integral' in k[1].code and len(k) == 2
 
 if __name__ == '__main__':
     import os


### PR DESCRIPTION
It turns out that the most convenient interface for both the PyOP2
and flop.py sides only involves passing a list of Kernels, each of
which correspond to the integral with the same index in the Form's
list of integrals.

This will need to be merged at the same time as 

https://code.launchpad.net/~mapdes/fluidity/pyop2-neumann/+merge/137332

in order to keep the APIs in sync.
