### PR TITLE
OpenCL -- Object Code Caching

### DIFF
--- a/pyop2/opencl.py
+++ b/pyop2/opencl.py
@@ -378,8 +378,6 @@ void global_%(type)s_%(dim)s_post_reduction (
             kernel = prg.__getattr__(name)
             _reduction_task_cache[(self.dtype, self.cdim, reduction_operator)] = (src, kernel)
 
-        src, kernel = _reduction_task_cache[(self.dtype, self.cdim, reduction_operator)]
-
         kernel.set_arg(0, self._array.data)
         kernel.set_arg(1, self._d_reduc_buffer)
         kernel.set_arg(2, np.int32(nelems))


### PR DESCRIPTION
Performs compiled machine code caching along with the generated code for both kernels' stubs and global reduction post kernel tasks.

some quick performance measurements are pretty encouraging:
- the backend with intel sdk is now roughly 20 times faster than before
- opencl seems to be faster than sequential on airfoil
