### PR TITLE
Python 2.6 compatibility fix

### DIFF
--- a/pyop2/device.py
+++ b/pyop2/device.py
@@ -31,7 +31,12 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+# OrderedDict was added in Python 2.7. Earlier versions can use ordereddict
+# from PyPI
+except ImportError:
+    from ordereddict import OrderedDict
 import numpy
 import op_lib_core as core
 import runtime_base as op2


### PR DESCRIPTION
`collections.OrderedDict` was introduced in Python 2.7, use `ordereddict` otherwise (install from PyPI)
