### PR TITLE
Check converged reason after iterative solve completes.

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -945,7 +945,8 @@ DEFAULT_SOLVER_PARAMETERS = {'linear_solver':      'cg',
                              'relative_tolerance': 1.0e-7,
                              'absolute_tolerance': 1.0e-50,
                              'divergence_tolerance': 1.0e+4,
-                             'maximum_iterations': 1000 }
+                             'maximum_iterations': 1000,
+                             'error_on_nonconvergence': True}
 
 class Solver(object):
     """OP2 Solver object. The :class:`Solver` holds a set of parameters that are

--- a/pyop2/runtime_base.py
+++ b/pyop2/runtime_base.py
@@ -268,4 +268,8 @@ class Solver(base.Solver, PETSc.KSP):
             print "Converged reason: %s" % self._reasons[r]
             print "Iterations: %s" % self.getIterationNumber()
         if r < 0:
-            raise RuntimeError("KSP Solver failed to converge: %s" % self._reasons[r])
+            if self.parameters['error_on_nonconvergence']:
+                raise RuntimeError("KSP Solver failed to converge: %s" % self._reasons[r])
+            else:
+                from warnings import warn
+                warn("KSP Solver failed to converge: %s" % self._reasons[r])


### PR DESCRIPTION
In order to avoid continuing when a solve hasn't converged, we raise an exception when the solver fails to converge.
