### PR TITLE
Check for ValueError on write to read-only Dats.

### DIFF
--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -254,14 +254,14 @@ class TestDatAPI:
         "Attempting to set values through the RO accessor should raise an error."
         d = op2.Dat(set, 2, range(2 * set.size), dtype=np.int32)
         x = d.data_ro
-        with pytest.raises(RuntimeError):
+        with pytest.raises((RuntimeError, ValueError)):
             x[0] = 1
 
     def test_dat_ro_write_accessor(self, backend, set):
         "Re-accessing the data in writeable form should be allowed."
         d = op2.Dat(set, 1, range(set.size), dtype=np.int32)
         x = d.data_ro
-        with pytest.raises(RuntimeError):
+        with pytest.raises((RuntimeError, ValueError)):
             x[0] = 1
         x = d.data
         x[0] = -100

--- a/test/unit/test_direct_loop.py
+++ b/test/unit/test_direct_loop.py
@@ -180,7 +180,7 @@ void kernel_soa(unsigned int * x) { OP2_STRIDE(x, 0) = 42; OP2_STRIDE(x, 1) = 43
         kernel = """void k(unsigned int *x) { *x = 1; }"""
         x_data = x.data
         op2.par_loop(op2.Kernel(kernel, 'k'), elems(), x(op2.IdentityMap, op2.WRITE))
-        with pytest.raises(RuntimeError):
+        with pytest.raises((RuntimeError, ValueError)):
             x_data[0] = 1
 
     def test_host_write_works(self, backend, x, g):


### PR DESCRIPTION
Recent versions of numpy throw a ValueError rather than a
RuntimeError when trying to write to a read-only array.

Buildbot pass: http://buildbot-ocean.ese.ic.ac.uk:8080/builders/pyop2-testing/builds/126
