### PR TITLE
Use Extension from distutils in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from setuptools import setup
+from distutils.extension import Extension
 import numpy
 import os, sys
 
@@ -50,18 +51,16 @@ OP2_LIB = OP2_DIR + '/c/lib'
 
 # If Cython is available, built the extension module from the Cython source
 try:
-    from Cython.Distutils import build_ext, Extension
+    from Cython.Distutils import build_ext
     cmdclass = {'build_ext' : build_ext}
     ext_modules = [Extension('pyop2.op_lib_core',
                              ['pyop2/op_lib_core.pyx', 'pyop2/_op_lib_core.pxd', 'pyop2/sparsity_utils.cxx'],
-                             pyrex_include_dirs=['pyop2'],
                              include_dirs=['pyop2', OP2_INC, numpy.get_include()],
                              library_dirs=[OP2_LIB],
                              runtime_library_dirs=[OP2_LIB],
                              libraries=["op2_seq"])]
 # Else we require the Cython-compiled .c file to be present and use that
 except ImportError:
-    from setuptools import Extension
     cmdclass = {}
     ext_modules = [Extension('pyop2.op_lib_core',
                              ['pyop2/op_lib_core.c', 'pyop2/sparsity_utils.cxx'],


### PR DESCRIPTION
It turns out we don't actually need Extension from Cython.Distutils.
The extension module builds fine with Extension from standard
distutils. In fact using Cython.Distutils.Extension requires a very
recent version of distribute which wasn't available by default on
recent Ubuntu systems and led to an awkward and hard to debug error.

[Buildbot pass](http://buildbot-ocean.ese.ic.ac.uk:8080/builders/pyop2-testing/builds/127) and confirmed working on cx1.
