### PR TITLE
Get PETSc directory from PETSC_DIR, import petsc if that fails

### DIFF
--- a/pyop2/openmp.py
+++ b/pyop2/openmp.py
@@ -35,13 +35,11 @@
 
 import os
 import numpy as np
-import petsc
 import math
 
 from exceptions import *
 from utils import *
 import op_lib_core as core
-from pyop2.utils import OP2_INC, OP2_LIB
 import runtime_base as rt
 from runtime_base import *
 import device
@@ -480,10 +478,10 @@ class ParLoop(device.ParLoop):
         os.environ['CC'] = 'mpicc'
         _fun = inline_with_numpy(code_to_compile, additional_declarations = kernel_code,
                                  additional_definitions = _const_decs + kernel_code,
-                                 include_dirs=[OP2_INC, petsc.get_petsc_dir()+'/include'],
+                                 include_dirs=[OP2_INC, get_petsc_dir()+'/include'],
                                  source_directory=os.path.dirname(os.path.abspath(__file__)),
                                  wrap_headers=["mat_utils.h"],
-                                 library_dirs=[OP2_LIB, petsc.get_petsc_dir()+'/lib'],
+                                 library_dirs=[OP2_LIB, get_petsc_dir()+'/lib'],
                                  libraries=['op2_seq', 'petsc'],
                                  sources=["mat_utils.cxx"],
                                  cppargs=['-fopenmp'],

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -35,12 +35,10 @@
 
 import os
 import numpy as np
-import petsc
 
 from exceptions import *
 from utils import *
 import op_lib_core as core
-from pyop2.utils import OP2_INC, OP2_LIB
 import runtime_base as rt
 from runtime_base import *
 
@@ -342,10 +340,10 @@ class ParLoop(rt.ParLoop):
         os.environ['CC'] = 'mpicc'
         _fun = inline_with_numpy(code_to_compile, additional_declarations = kernel_code,
                                  additional_definitions = _const_decs + kernel_code,
-                                 include_dirs=[OP2_INC, petsc.get_petsc_dir()+'/include'],
+                                 include_dirs=[OP2_INC, get_petsc_dir()+'/include'],
                                  source_directory=os.path.dirname(os.path.abspath(__file__)),
                                  wrap_headers=["mat_utils.h"],
-                                 library_dirs=[OP2_LIB, petsc.get_petsc_dir()+'/lib'],
+                                 library_dirs=[OP2_LIB, get_petsc_dir()+'/lib'],
                                  libraries=['op2_seq', 'petsc'],
                                  sources=["mat_utils.cxx"])
         if cc:

--- a/pyop2/utils.py
+++ b/pyop2/utils.py
@@ -250,6 +250,19 @@ def comment_remover(text):
                          re.DOTALL | re.MULTILINE)
     return re.sub(pattern, replacer, text)
 
+def get_petsc_dir():
+    try:
+        return os.environ['PETSC_DIR']
+    except KeyError:
+        try:
+            import petsc
+            return petsc.get_petsc_dir()
+        except ImportError:
+            sys.exit("""Error: Could not find PETSc library.
+
+Set the environment variable PETSC_DIR to your local PETSc base
+directory or install PETSc from PyPI: pip install petsc""")
+
 try:
     OP2_DIR = os.environ['OP2_DIR']
 except KeyError:


### PR DESCRIPTION
In sequential and openmp we imported petsc for the sole purpose of
calling get_petsc_dir(). This will only work if PETSc has been
installed from PyPI because only in this case there will be a PETSc
python module.

Instead we first attempt to read the environment variable PETSC_DIR,
failing that we attempt to import petsc to call get_petsc_dir() and
failing that we abort printing a helpful error message.

[Buildbot pass](http://buildbot-ocean.ese.ic.ac.uk:8080/builders/pyop2-testing/builds/128)
