### PR TITLE
Outsource finding OP2 lib and include directories to find_op2 module

### DIFF
--- a/pyop2/find_op2.py
+++ b/pyop2/find_op2.py
@@ -1,0 +1,51 @@
+# This file is part of PyOP2
+#
+# PyOP2 is Copyright (c) 2012, Imperial College London and
+# others. Please see the AUTHORS file in the main source directory for
+# a full list of copyright holders.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * The name of Imperial College London or that of other
+#       contributors may not be used to endorse or promote products
+#       derived from this software without specific prior written
+#       permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTERS
+# ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os, sys
+
+try:
+    OP2_DIR = os.environ['OP2_DIR']
+    OP2_INC = OP2_DIR + '/c/include'
+    OP2_LIB = OP2_DIR + '/c/lib'
+except KeyError:
+    try:
+        OP2_PREFIX = os.environ['OP2_PREFIX']
+        OP2_INC = OP2_PREFIX + '/include'
+        OP2_LIB = OP2_PREFIX + '/lib'
+    except KeyError:
+        sys.exit("""Error: Could not find OP2 library.
+
+Set the environment variable OP2_DIR to point to the op2 subdirectory
+of your OP2 source tree or OP2_PREFIX to point to the location of an
+OP2 installation.""")
+

--- a/pyop2/openmp.py
+++ b/pyop2/openmp.py
@@ -38,6 +38,7 @@ import numpy as np
 import math
 
 from exceptions import *
+from find_op2 import *
 from utils import *
 import op_lib_core as core
 import runtime_base as rt

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -37,6 +37,7 @@ import os
 import numpy as np
 
 from exceptions import *
+from find_op2 import *
 from utils import *
 import op_lib_core as core
 import runtime_base as rt

--- a/pyop2/utils.py
+++ b/pyop2/utils.py
@@ -262,14 +262,3 @@ def get_petsc_dir():
 
 Set the environment variable PETSC_DIR to your local PETSc base
 directory or install PETSc from PyPI: pip install petsc""")
-
-try:
-    OP2_DIR = os.environ['OP2_DIR']
-except KeyError:
-    sys.exit("""Error: Could not find OP2 library.
-
-Set the environment variable OP2_DIR to point to the op2 subdirectory
-of your OP2 source tree""")
-
-OP2_INC = OP2_DIR + '/c/include'
-OP2_LIB = OP2_DIR + '/c/lib'

--- a/setup.py
+++ b/setup.py
@@ -38,16 +38,8 @@ from distutils.extension import Extension
 import numpy
 import os, sys
 
-try:
-    OP2_DIR = os.environ['OP2_DIR']
-except KeyError:
-    sys.exit("""Error: Could not find OP2 library.
-
-Set the environment variable OP2_DIR to point to the op2 subdirectory
-of your OP2 source tree""")
-
-OP2_INC = OP2_DIR + '/c/include'
-OP2_LIB = OP2_DIR + '/c/lib'
+# Find OP2 include and library directories
+execfile('pyop2/find_op2.py')
 
 # If Cython is available, built the extension module from the Cython source
 try:


### PR DESCRIPTION
This module is imported by sequential and openmp and executed by
setup.py. That is necessary because setup.py cannot import a module
from a package without inheriting all its dependencies. Read more on
SO: http://stackoverflow.com/a/2073599/396967

Also support setting OP2_PREFIX instead of OP2_DIR to specify an
install location in a case where OP2 has not been built in the source
tree.

[Buildbot pass](http://buildbot-ocean.ese.ic.ac.uk:8080/builders/pyop2-testing/builds/131)
