### PR TITLE
Dat.data_ro returns read-only view of the data

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1085,8 +1085,9 @@ class Dat(DataCarrier):
         _trace.evaluate(set([self]), set())
         if self.dataset.total_size > 0 and self._data.size == 0:
             raise RuntimeError("Illegal access: no data associated with this Dat!")
-        maybe_setflags(self._data, write=False)
-        return self._data
+        v = self._data.view()
+        v.setflags(write=False)
+        return v
 
     def save(self, filename):
         """Write the data array to file ``filename`` in NumPy format."""

--- a/pyop2/device.py
+++ b/pyop2/device.py
@@ -157,8 +157,9 @@ class DeviceDataMixin(object):
         self._from_device()
         if self.state is not DeviceDataMixin.DEVICE_UNALLOCATED:
             self.state = DeviceDataMixin.BOTH
-        maybe_setflags(self._data, write=False)
-        return self._data
+        v = self._data.view()
+        v.setflags(write=False)
+        return v
 
     def _maybe_to_soa(self, data):
         """Convert host data to SoA order for device upload if necessary


### PR DESCRIPTION
Remove all calls to maybe_setflags and leave Dat._data always writable.
We can use needs_halo_update as a dirty flag. It is being set when
accessing Dat.data but not Dat.data_ro.

Previously we had the issue that a Dat argument to a parallel loop
might require a halo update, but was set read-only.

One of the semantics we lose with this change is data acquired with
Dat.data becoming "magically" read-only after a par loop.
