### PR TITLE
Allow a Dat to be declared without any data.

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -480,7 +480,7 @@ class Dat(DataCarrier):
     using the :data:`IdentityMap` as the indirection.
 
     ``Dat`` objects support the pointwise linear algebra operations +=, *=,
-    -=, /=, where *= and /= also support multiplication/dvision by a scalar.
+    -=, /=, where *= and /= also support multiplication/division by a scalar.
     """
 
     _globalcount = 0

--- a/pyop2/runtime_base.py
+++ b/pyop2/runtime_base.py
@@ -223,8 +223,15 @@ class Halo(base.Halo):
 class Dat(base.Dat):
     """OP2 vector data. A ``Dat`` holds a value for every member of a :class:`Set`."""
 
+    @validate_type(('dataset', Set, SetTypeError))
     def __init__(self, dataset, dim, data=None, dtype=None, name=None,
                  soa=None, uid=None):
+        try:
+            dim = tuple(dim)
+        except TypeError:
+            dim = (dim,)
+        if data is None:
+            data = np.zeros(dataset.total_size*np.prod(dim))
         base.Dat.__init__(self, dataset, dim, data, dtype, name, soa, uid)
         halo = dataset.halo
         if halo is not None:

--- a/pyop2/utils.py
+++ b/pyop2/utils.py
@@ -163,15 +163,15 @@ class validate_range(validate_base):
 def verify_reshape(data, dtype, shape, allow_none=False):
     """Verify data is of type dtype and try to reshaped to shape."""
 
+    try:
+        t = np.dtype(dtype) if dtype is not None else None
+    except TypeError:
+        raise DataTypeError("Invalid data type: %s" % dtype)
     if data is None and allow_none:
-        try:
-            return np.asarray([], dtype=np.dtype(dtype))
-        except TypeError:
-            raise DataTypeError("Invalid data type: %s" % dtype)
+        return np.asarray([], dtype=t)
     elif data is None:
         raise DataValueError("Invalid data: None is not allowed!")
     else:
-        t = np.dtype(dtype) if dtype is not None else None
         try:
             a = np.asarray(data, dtype=t)
         except ValueError:

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -175,12 +175,29 @@ class TestDatAPI:
         with pytest.raises(exceptions.NameTypeError):
             op2.Dat(set, 1, name=2)
 
-    def test_dat_illegal_data_access(self, backend, set):
-        """Dat initialised without data should raise an exception when
-        accessing the data."""
+    def test_dat_initialise_data(self, backend, set):
+        """Dat initilialised without the data should initialise data with the
+        correct size and type."""
         d = op2.Dat(set, 1)
-        with pytest.raises(RuntimeError):
-            d.data
+        assert d.data.size == 5 and d.data.dtype == np.float64
+
+    def test_dat_initialise_vector_data(self, backend, set):
+        """Dat initilialised without the data should initialise data with the
+        correct size and type - vector data case."""
+        d = op2.Dat(set, 2)
+        assert d.data.size == 10 and d.data.dtype == np.float64
+
+    def test_dat_initialise_dimlist_data(self, backend, set):
+        """Dat initilialised without the data should initialise data with the
+        correct size and type - list of dims case."""
+        d = op2.Dat(set, [2, 3])
+        assert d.data.size == 30 and d.data.dtype == np.float64
+
+    def test_dat_initialise_data_type(self, backend, set):
+        """Dat intiialised without the data but with specified type should
+        initialise its data with the correct type."""
+        d = op2.Dat(set, 1, dtype=np.int32)
+        assert d.data.size == 5 and d.data.dtype == np.int32
 
     def test_dat_illegal_map(self, backend, set):
         """Dat __call__ should not allow a map with a dataset other than this


### PR DESCRIPTION
When no data is passed, a numpy array of the requisite size and type is created by the runtime. 

This saves you from having to create an array or list of the correct size to pass in, if you are going to overwrite the initial data without reading it first.
