### PR TITLE
Fix for using Firedrake with CUDA

### DIFF
--- a/pyop2/cuda.py
+++ b/pyop2/cuda.py
@@ -280,7 +280,7 @@ class Mat(DeviceDataMixin, op2.Mat):
                             np.int32(nelems)])
             fun = vfun
         _stream.synchronize()
-        fun.prepared_async_call((nblock, 1, 1), (nthread, 1, 1), _stream, *arglist)
+        fun.prepared_async_call((int(nblock), 1, 1), (nthread, 1, 1), _stream, *arglist)
 
     @property
     def values(self):
@@ -635,8 +635,8 @@ class Solver(base.Solver):
                      M._csrdata,
                      b._device_data,
                      x._device_data,
-                     b.dataset.size * b.cdim,
-                     x.dataset.size * x.cdim,
+                     int(b.dataset.size * b.cdim),
+                     int(x.dataset.size * x.cdim),
                      M._csrdata.size)
         x.state = DeviceDataMixin.DEVICE
 


### PR DESCRIPTION
nblock and the size of datasets seem to be `numpy.int64` types when running with Firedrake.

This commit converts them to `int` before passing them to PyCUDA. 

The Firedrake tests can pass with the CUDA backend, with the following exceptions:
- The identity test for degrees 3 and 4 is problematic because it makes cicc (part of the CUDA compiler) go into a slow loop consuming 100% CPU. It eventually finished compiling for degree 3 after about 10 minutes but I didn't wait for the degree 4 case to finish compiling. 
- The identity_parallel test fails - I think this would be expected anyway - IIUC this tests with MPI.

Thanks to @wence- for suggesting that this is the correct fix.

Buildbot pass: http://buildbot-ocean.ese.ic.ac.uk:8080/builders/pyop2-testing/builds/499
