### PR TITLE
Fix map checking

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -202,7 +202,7 @@ class Arg(object):
         if self._is_global or map is None:
             return
         for j, m in enumerate(map):
-            if not len(m.values):
+            if m.iterset.total_size > 0 and len(m.values) == 0:
                 raise MapValueError("%s is not initialized." % map)
             if self._is_mat and m.toset != data.sparsity.dsets[j].set:
                 raise MapValueError(

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -1173,7 +1173,6 @@ class TestParLoopAPI:
             op2.par_loop(kernel, set1,
                          m(op2.INC, (rmap[op2.i[0]], cmap[op2.i[1]])))
 
-    @pytest.mark.xfail
     def test_empty_map_and_iterset(self, backend):
         """If the iterset of the ParLoop is zero-sized, it should not matter if
         a map defined on it has no values."""


### PR DESCRIPTION
Argument checking for maps whose iteration set was zero-length was broken.  This fixes it and adds a test.
