### PR TITLE
Switch to PETSc naming for solver options

### DIFF
--- a/demo/laplace_ffc.py
+++ b/demo/laplace_ffc.py
@@ -136,7 +136,7 @@ def main(opt):
                  bdry(op2.READ),
                  b(op2.WRITE, bdry_node_node[0]))
 
-    solver = op2.Solver(linear_solver='gmres')
+    solver = op2.Solver(ksp_type='gmres')
     solver.solve(mat, x, b)
 
     # Print solution

--- a/demo/weak_bcs_ffc.py
+++ b/demo/weak_bcs_ffc.py
@@ -168,7 +168,7 @@ def main(opt):
                  bdry(op2.READ),
                  b(op2.WRITE, bdry_node_node[0]))
 
-    solver = op2.Solver(linear_solver='gmres')
+    solver = op2.Solver(ksp_type='gmres')
     solver.solve(mat, x, b)
 
     # Print solution

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2053,21 +2053,20 @@ class ParLoop(LazyComputation):
         """Flag which triggers extrusion"""
         return self._is_layered
 
-DEFAULT_SOLVER_PARAMETERS = {'linear_solver': 'cg',
-                             'preconditioner': 'jacobi',
-                             'relative_tolerance': 1.0e-7,
-                             'absolute_tolerance': 1.0e-50,
-                             'divergence_tolerance': 1.0e+4,
-                             'maximum_iterations': 1000,
-                             'monitor_convergence': False,
+DEFAULT_SOLVER_PARAMETERS = {'ksp_type': 'cg',
+                             'pc_type': 'jacobi',
+                             'ksp_rtol': 1.0e-7,
+                             'ksp_atol': 1.0e-50,
+                             'ksp_divtol': 1.0e+4,
+                             'ksp_max_it': 1000,
+                             'ksp_monitor': False,
                              'plot_convergence': False,
                              'plot_prefix': '',
                              'error_on_nonconvergence': True,
-                             'gmres_restart': 30}
+                             'ksp_gmres_restart': 30}
 
-"""The default parameters for the solver are the same as those used in PETSc
-3.3. Note that the parameters accepted by :class:`op2.Solver` are only a subset
-of all PETSc parameters."""
+"""All parameters accepted by PETSc KSP and PC objects are permissible
+as options to the :class:`op2.Solver`."""
 
 
 class Solver(object):

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -1185,30 +1185,30 @@ class TestSolverAPI:
         assert s.parameters == base.DEFAULT_SOLVER_PARAMETERS
 
     def test_set_options_with_params(self, backend):
-        params = {'linear_solver': 'gmres',
-                  'maximum_iterations': 25}
+        params = {'ksp_type': 'gmres',
+                  'ksp_max_it': 25}
         s = op2.Solver(params)
-        assert s.parameters['linear_solver'] == 'gmres' \
-            and s.parameters['maximum_iterations'] == 25
+        assert s.parameters['ksp_type'] == 'gmres' \
+            and s.parameters['ksp_max_it'] == 25
 
     def test_set_options_with_kwargs(self, backend):
-        s = op2.Solver(linear_solver='gmres', maximum_iterations=25)
-        assert s.parameters['linear_solver'] == 'gmres' \
-            and s.parameters['maximum_iterations'] == 25
+        s = op2.Solver(ksp_type='gmres', ksp_max_it=25)
+        assert s.parameters['ksp_type'] == 'gmres' \
+            and s.parameters['ksp_max_it'] == 25
 
     def test_update_parameters(self, backend):
         s = op2.Solver()
-        params = {'linear_solver': 'gmres',
-                  'maximum_iterations': 25}
+        params = {'ksp_type': 'gmres',
+                  'ksp_max_it': 25}
         s.update_parameters(params)
-        assert s.parameters['linear_solver'] == 'gmres' \
-            and s.parameters['maximum_iterations'] == 25
+        assert s.parameters['ksp_type'] == 'gmres' \
+            and s.parameters['ksp_max_it'] == 25
 
     def test_set_params_and_kwargs_illegal(self, backend):
-        params = {'linear_solver': 'gmres',
-                  'maximum_iterations': 25}
+        params = {'ksp_type': 'gmres',
+                  'ksp_max_it': 25}
         with pytest.raises(RuntimeError):
-            op2.Solver(params, linear_solver='cgs')
+            op2.Solver(params, ksp_type='cgs')
 
 if __name__ == '__main__':
     import os


### PR DESCRIPTION
We already use PETSc options names in Firedrake, and since it's the only
linear algebra backend we support just use the PETSc names
directly. This way, it's much easier to adjust to PETSc option name
changes (or new options appearing), they're already supported.
