### PR TITLE
Can't set config values via environment variables

### DIFF
--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -1,0 +1,126 @@
+# This file is part of PyOP2
+#
+# PyOP2 is Copyright (c) 2012, Imperial College London and
+# others. Please see the AUTHORS file in the main source directory for
+# a full list of copyright holders.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * The name of Imperial College London or that of other
+#       contributors may not be used to endorse or promote products
+#       derived from this software without specific prior written
+#       permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTERS
+# ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""PyOP2 global configuration."""
+
+import copy
+import os
+from tempfile import gettempdir
+
+from exceptions import ConfigurationError
+
+
+class Configuration(object):
+    """PyOP2 configuration parameters
+
+    :param backend: Select the PyOP2 backend (one of `cuda`,
+        `opencl`, `openmp` or `sequential`).
+    :param debug: Turn on debugging for generated code (turns off
+        compiler optimisations).
+    :param log_level: How chatty should PyOP2 be?  Valid values
+        are "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL".
+    :param lazy_evaluation: Should lazy evaluation be on or off?
+    :param lazy_max_trace_length: How many :func:`par_loop`\s
+        should be queued lazily before forcing evaluation?  Pass
+        `0` for an unbounded length.
+    :param dump_gencode: Should PyOP2 write the generated code
+        somewhere for inspection?
+    :param dump_gencode_path: Where should the generated code be
+        written to?
+    """
+    # name, env variable, type, default, write once
+    DEFAULTS = {
+        "backend": ("PYOP2_BACKEND", str, "sequential"),
+        "debug": ("PYOP2_DEBUG", int, 0),
+        "log_level": ("PYOP2_LOG_LEVEL", (str, int), "WARNING"),
+        "lazy_evaluation": ("PYOP2_LAZY", bool, True),
+        "lazy_max_trace_length": ("PYOP2_MAX_TRACE_LENGTH", int, 0),
+        "dump_gencode": ("PYOP2_DUMP_GENCODE", bool, False),
+        "dump_gencode_path": ("PYOP2_DUMP_GENCODE_PATH", str,
+                              os.path.join(gettempdir(), "pyop2-gencode")),
+    }
+    """Default values for PyOP2 configuration parameters"""
+    READONLY = ['backend']
+    """List of read-only configuration keys."""
+
+    def __init__(self):
+        def convert(env, typ, v):
+            if not isinstance(typ, type):
+                typ = typ[0]
+            try:
+                return typ(os.environ.get(env, v))
+            except ValueError:
+                raise ValueError("Cannot convert value of environment variable %s to %r" % (env, typ))
+        self._conf = dict((k, convert(env, typ, v))
+                          for k, (env, typ, v) in Configuration.DEFAULTS.items())
+        self._set = set()
+        self._defaults = copy.copy(self._conf)
+
+    def reset(self):
+        """Reset the configuration parameters to the default values."""
+        self._conf = copy.copy(self._defaults)
+        self._set = set()
+
+    def reconfigure(self, **kwargs):
+        """Update the configuration parameters with new values."""
+        for k, v in kwargs.items():
+            self[k] = v
+
+    def __getitem__(self, key):
+        """Return the value of a configuration parameter.
+
+        :arg key: The parameter to query"""
+        return self._conf[key]
+
+    def __setitem__(self, key, value):
+        """Set the value of a configuration parameter.
+
+        :arg key: The parameter to set
+        :arg value: The value to set it to.
+
+        .. note::
+           Some configuration parameters are read-only in which case
+           attempting to set them raises an error, see
+           :attr:`Configuration.READONLY` for details of which.
+        """
+        if key in Configuration.READONLY and key in self._set and value != self[key]:
+            raise ConfigurationError("%s is read only" % key)
+        if key in Configuration.DEFAULTS:
+            valid_type = Configuration.DEFAULTS[key][1]
+            if not isinstance(value, valid_type):
+                raise ConfigurationError("Values for configuration key %s must be of type %r, not %r"
+                                         % (key, valid_type, type(value)))
+        self._set.add(key)
+        self._conf[key] = value
+
+configuration = Configuration()

--- a/pyop2/cuda.py
+++ b/pyop2/cuda.py
@@ -33,7 +33,7 @@
 
 import base
 from device import *
-from base import configuration as cfg
+from configuration import configuration
 import device as op2
 import plan
 import numpy as np
@@ -638,7 +638,7 @@ def _cusp_solver(M, parameters):
     nvcc_toolchain.cflags.append('-arch')
     nvcc_toolchain.cflags.append('sm_20')
     nvcc_toolchain.cflags.append('-O3')
-    module = nvcc_mod.compile(gcc_toolchain, nvcc_toolchain, debug=cfg["debug"])
+    module = nvcc_mod.compile(gcc_toolchain, nvcc_toolchain, debug=configuration["debug"])
 
     _cusp_cache[cache_key(M.ctype, parameters)] = module
     return module

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -38,6 +38,7 @@ from textwrap import dedent
 
 import base
 from base import *
+from configuration import configuration
 from utils import as_tuple, flatten
 
 
@@ -392,7 +393,7 @@ class JITModule(base.JITModule):
             inline %(code)s
             """ % {'code': self._kernel.code}
         code_to_compile = strip(dedent(self._wrapper) % self.generate_code())
-        if base.configuration["debug"]:
+        if configuration["debug"]:
             self._wrapper_code = code_to_compile
 
         _const_decs = '\n'.join([const._format_declaration()
@@ -405,7 +406,7 @@ class JITModule(base.JITModule):
         self._fun = inline_with_numpy(
             code_to_compile, additional_declarations=kernel_code,
             additional_definitions=_const_decs + kernel_code,
-            cppargs=self._cppargs + (['-O0', '-g'] if base.configuration["debug"] else []),
+            cppargs=self._cppargs + (['-O0', '-g'] if configuration["debug"] else []),
             include_dirs=[d + '/include' for d in get_petsc_dir()],
             source_directory=os.path.dirname(os.path.abspath(__file__)),
             wrap_headers=["mat_utils.h"],
@@ -413,7 +414,7 @@ class JITModule(base.JITModule):
             library_dirs=[d + '/lib' for d in get_petsc_dir()],
             libraries=['petsc'] + self._libraries,
             sources=["mat_utils.cxx"],
-            modulename=self._kernel.name if base.configuration["debug"] else None)
+            modulename=self._kernel.name if configuration["debug"] else None)
         if cc:
             os.environ['CC'] = cc
         else:

--- a/pyop2/op2.py
+++ b/pyop2/op2.py
@@ -37,7 +37,8 @@ import atexit
 
 import backends
 import base
-from base import configuration, READ, WRITE, RW, INC, MIN, MAX, i
+from base import READ, WRITE, RW, INC, MIN, MAX, i
+from configuration import configuration
 from logger import debug, info, warning, error, critical, set_log_level
 from mpi import MPI, collective
 from utils import validate_type
@@ -94,7 +95,7 @@ def init(**kwargs):
     set_log_level(configuration['log_level'])
     if backend == 'pyop2.void':
         try:
-            backends.set_backend(base.configuration["backend"])
+            backends.set_backend(configuration["backend"])
         except:
             configuration.reset()
             raise

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -213,44 +213,6 @@ class TestClassAPI:
         assert not issubclass(type(dat), op2.Set)
 
 
-class TestConfigurationAPI:
-    """Configuration API unit tests."""
-
-    def test_add_configuration_value(self):
-        """Defining an non default argument."""
-        c = base.Configuration()
-        c.reconfigure(foo='bar')
-        assert c['foo'] == 'bar'
-
-    def test_change_backend(self):
-        """backend option is read only."""
-        c = base.Configuration()
-        c.reconfigure(backend='cuda')
-        with pytest.raises(exceptions.ConfigurationError):
-            c['backend'] = 'other'
-
-    def test_reconfigure_backend(self):
-        """backend option is read only."""
-        c = base.Configuration()
-        c.reconfigure(backend='cuda')
-        with pytest.raises(exceptions.ConfigurationError):
-            c.reconfigure(backend='other')
-
-    @pytest.mark.parametrize(('key', 'val'), [('backend', 0),
-                                              ('debug', 'illegal'),
-                                              ('log_level', 1.5),
-                                              ('lazy_evaluation', 'illegal'),
-                                              ('lazy_max_trace_length', 'illegal'),
-                                              ('dump_gencode', 'illegal'),
-                                              ('dump_gencode_path', 0)])
-    def test_configuration_illegal_types(self, key, val):
-        """Illegal types for configuration values should raise
-        ConfigurationError."""
-        c = base.Configuration()
-        with pytest.raises(exceptions.ConfigurationError):
-            c[key] = val
-
-
 class TestInitAPI:
 
     """

--- a/test/unit/test_configuration.py
+++ b/test/unit/test_configuration.py
@@ -1,0 +1,76 @@
+# This file is part of PyOP2
+#
+# PyOP2 is Copyright (c) 2012, Imperial College London and
+# others. Please see the AUTHORS file in the main source directory for
+# a full list of copyright holders.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * The name of Imperial College London or that of other
+#       contributors may not be used to endorse or promote products
+#       derived from this software without specific prior written
+#       permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTERS
+# ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Configuration unit tests."""
+
+import pytest
+from pyop2.configuration import Configuration
+from pyop2.exceptions import ConfigurationError
+
+
+class TestConfigurationAPI:
+    """Configuration API unit tests."""
+
+    def test_add_configuration_value(self):
+        """Defining an non default argument."""
+        c = Configuration()
+        c.reconfigure(foo='bar')
+        assert c['foo'] == 'bar'
+
+    def test_change_backend(self):
+        """backend option is read only."""
+        c = Configuration()
+        c.reconfigure(backend='cuda')
+        with pytest.raises(ConfigurationError):
+            c['backend'] = 'other'
+
+    def test_reconfigure_backend(self):
+        """backend option is read only."""
+        c = Configuration()
+        c.reconfigure(backend='cuda')
+        with pytest.raises(ConfigurationError):
+            c.reconfigure(backend='other')
+
+    @pytest.mark.parametrize(('key', 'val'), [('backend', 0),
+                                              ('debug', 'illegal'),
+                                              ('log_level', 1.5),
+                                              ('lazy_evaluation', 'illegal'),
+                                              ('lazy_max_trace_length', 'illegal'),
+                                              ('dump_gencode', 'illegal'),
+                                              ('dump_gencode_path', 0)])
+    def test_configuration_illegal_types(self, key, val):
+        """Illegal types for configuration values should raise
+        ConfigurationError."""
+        c = Configuration()
+        with pytest.raises(ConfigurationError):
+            c[key] = val


### PR DESCRIPTION
```
export PYOP2_DEBUG=1
from pyop2 import op2
op2.init()

print op2.configuration['debug']
 => 0
```

should be 1.
