### PR TITLE
Separate read and write intent in _force_evaluation

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1330,9 +1330,16 @@ class DataCarrier(object):
         the product of the dim tuple."""
         return self._cdim
 
-    def _force_evaluation(self):
-        """Force the evaluation of any outstanding computation to ensure that this DataCarrier is up to date"""
-        _trace.evaluate(set([self]), set([self]))
+    def _force_evaluation(self, read=True, write=True):
+        """Force the evaluation of any outstanding computation to ensure that this DataCarrier is up to date.
+
+        Arguments read and write specify the intent you wish to observe the data with.
+
+        :arg read: if `True` force evaluation that writes to this DataCarrier.
+        :arg write: if `True` force evaluation that reads from this DataCarrier."""
+        reads = self if read else None
+        writes = self if write else None
+        _trace.evaluate(reads, writes)
 
 
 class Dat(DataCarrier):


### PR DESCRIPTION
Previously, `_force_evaluation` evaluated all dependent computation.
Add arguments that specify whether the intent is to only force
computation that depends on reads or writes or both.
