### PR TITLE
Fix Mat._is_scalar_field for mixed x Non-mixed case

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2748,7 +2748,9 @@ class Mat(DataCarrier):
 
     @property
     def _is_scalar_field(self):
-        return np.prod(self.dims) == 1
+        # Sparsity from Dat to MixedDat has a shape like (1, (1, 1))
+        # (which you can't take the product of)
+        return all(np.prod(d) == 1 for d in self.dims)
 
     @property
     def _is_vector_field(self):


### PR DESCRIPTION
If one of datasets in a Mat is mixed and the other isn't, the dims
property is something like (x, (y, z)).  So calling np.prod when
determining if the Mat represents as scalar field fails.  Check for
scalar-ness by checking that np.prod of every entry in the tuple is 1
instead.
