### PR TITLE
Openmp threads

### DIFF
--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -120,8 +120,6 @@ class Arg(base.Arg):
         elif self._is_mat:
             val += "Mat %(iname)s = %(name)s_;\n" % {'name': self.c_arg_name(),
                                                      'iname': self.c_arg_name(0, 0)}
-        if self._is_vec_map:
-            val += self.c_vec_dec(is_facet=is_facet)
         return val
 
     def c_ind_data(self, idx, i, j=0, is_top=False, layers=1, offset=None):
@@ -738,6 +736,8 @@ class JITModule(base.JITModule):
         # an extruded mesh.
         _wrapper_decs = ';\n'.join([arg.c_wrapper_dec(is_facet=is_facet) for arg in self._args])
 
+        _vec_decs = ';\n'.join([arg.c_vec_dec(is_facet=is_facet) for arg in self._args if arg._is_vec_map])
+
         if len(Const._defs) > 0:
             _const_args = ', '
             _const_args += ', '.join([c_const_arg(c) for c in Const._definitions()])
@@ -908,6 +908,7 @@ class JITModule(base.JITModule):
                 'off_args': _off_args,
                 'layer_arg': _layer_arg,
                 'map_decl': indent(_map_decl, 2),
+                'vec_decs': indent(_vec_decs, 2),
                 'map_init': indent(_map_init, 5),
                 'apply_offset': indent(_apply_offset, 3),
                 'extr_loop': indent(_extr_loop, 5),

--- a/pyop2/openmp.py
+++ b/pyop2/openmp.py
@@ -70,9 +70,6 @@ def _detect_openmp_flags():
 
 class Arg(host.Arg):
 
-    def c_vec_name(self, idx=None):
-        return self.c_arg_name() + "_vec[%s]" % (idx or 'tid')
-
     def c_kernel_arg_name(self, i, j, idx=None):
         return "p_%s[%s]" % (self.c_arg_name(i, j), idx or 'tid')
 
@@ -83,7 +80,7 @@ class Arg(host.Arg):
         cdim = self.data.dataset.cdim if self._flatten else 1
         return ";\n%(type)s *%(vec_name)s[%(arity)s]" % \
             {'type': self.ctype,
-             'vec_name': self.c_vec_name(str(_max_threads)),
+             'vec_name': self.c_vec_name(),
              'arity': self.map.arity * cdim * (2 if is_facet else 1)}
 
     def padding(self):
@@ -158,6 +155,7 @@ void %(wrapper_name)s(int boffset,
     int tid = omp_get_thread_num();
     %(interm_globals_decl)s;
     %(interm_globals_init)s;
+    %(vec_decs)s;
 
     #pragma omp for schedule(static)
     for ( int __b = boffset; __b < boffset + nblocks; __b++ )

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -58,6 +58,7 @@ void %(wrapper_name)s(int start, int end,
   %(wrapper_decs)s;
   %(const_inits)s;
   %(map_decl)s
+  %(vec_decs)s;
   for ( int n = start; n < end; n++ ) {
     int i = %(index_expr)s;
     %(vec_inits)s;


### PR DESCRIPTION
Move extruded map and arg_vec declaration at the beginning of the parallel region to solve issue #289 .

Extra:
The first commit solves issue #289 by leaving the declarations in place and then making the extruded maps and the arg_vec variables private to each thread. Unless someone has some reason (due to future functionality) to go for this variant then the previous alternative will be merged into trunk.
