### PR TITLE
Add missing optional arguments to Map and Kernel on device

### DIFF
--- a/pyop2/cuda.py
+++ b/pyop2/cuda.py
@@ -47,10 +47,10 @@ from pycparser import c_parser, c_ast, c_generator
 
 class Kernel(op2.Kernel):
 
-    def __init__(self, code, name):
+    def __init__(self, code, name, opts={}):
         if self._initialized:
             return
-        op2.Kernel.__init__(self, code, name)
+        op2.Kernel.__init__(self, code, name, opts)
         self._code = self.instrument()
 
     def instrument(self):

--- a/pyop2/device.py
+++ b/pyop2/device.py
@@ -41,7 +41,7 @@ from mpi import collective
 class Kernel(base.Kernel):
 
     @classmethod
-    def _ast_to_c(cls, ast, name):
+    def _ast_to_c(cls, ast, name, opts={}):
         """Transform an Abstract Syntax Tree representing the kernel into a
         string of code (C syntax) suitable to GPU execution."""
         if not isinstance(ast, Node):

--- a/pyop2/opencl.py
+++ b/pyop2/opencl.py
@@ -53,8 +53,8 @@ class Kernel(device.Kernel):
 
     """OP2 OpenCL kernel type."""
 
-    def __init__(self, code, name):
-        device.Kernel.__init__(self, code, name)
+    def __init__(self, code, name, opts={}):
+        device.Kernel.__init__(self, code, name, opts)
 
     class Instrument(c_ast.NodeVisitor):
 


### PR DESCRIPTION
These were added only for the host so far. We just pass them through
to the base class constructor.
