### PR TITLE
added curly braces around consts

### DIFF
--- a/pyop2/pyop2_geometry.h
+++ b/pyop2/pyop2_geometry.h
@@ -80,18 +80,18 @@
 
 /// Compute Jacobian (pseudo)inverse K for interval embedded in R^2
 #define compute_jacobian_inverse_interval_2d(K, det, J) \
-  const double det2 = J[0]*J[0] + J[1]*J[1]; \
+  do { const double det2 = J[0]*J[0] + J[1]*J[1]; \
   det = sqrt(det2); \
   K[0] = J[0] / det2; \
-  K[1] = J[1] / det2; \
+  K[1] = J[1] / det2; } while (0)
 
 /// Compute Jacobian (pseudo)inverse K for interval embedded in R^3
 #define compute_jacobian_inverse_interval_3d(K, det, J) \
-  const double det2 = J[0]*J[0] + J[1]*J[1] + J[2]*J[2]; \
+  do { const double det2 = J[0]*J[0] + J[1]*J[1] + J[2]*J[2]; \
   det = sqrt(det2); \
   K[0] = J[0] / det2; \
   K[1] = J[1] / det2; \
-  K[2] = J[2] / det2;
+  K[2] = J[2] / det2; } while (0)
 
 /// Compute Jacobian inverse K for triangle embedded in R^2
 #define compute_jacobian_inverse_triangle_2d(K, det, J) \
@@ -103,7 +103,7 @@
 
 /// Compute Jacobian (pseudo)inverse K for triangle embedded in R^3
 #define compute_jacobian_inverse_triangle_3d(K, det, J) \
-  const double d_0 = J[2]*J[5] - J[4]*J[3]; \
+  do { const double d_0 = J[2]*J[5] - J[4]*J[3]; \
   const double d_1 = J[4]*J[1] - J[0]*J[5]; \
   const double d_2 = J[0]*J[3] - J[2]*J[1]; \
   const double c_0 = J[0]*J[0] + J[2]*J[2] + J[4]*J[4]; \
@@ -117,7 +117,7 @@
   K[2] = (J[4]*c_1 - J[5]*c_2) / den; \
   K[3] = (J[1]*c_0 - J[0]*c_2) / den; \
   K[4] = (J[3]*c_0 - J[2]*c_2) / den; \
-  K[5] = (J[5]*c_0 - J[4]*c_2) / den;
+  K[5] = (J[5]*c_0 - J[4]*c_2) / den; } while (0)
 
 /// Compute Jacobian (pseudo)inverse K for quad embedded in R^2
 #define compute_jacobian_inverse_quad_2d compute_jacobian_inverse_triangle_2d
@@ -127,7 +127,7 @@
 
 /// Compute Jacobian inverse K for tetrahedron embedded in R^3
 #define compute_jacobian_inverse_tetrahedron_3d(K, det, J) \
-  const double d_00 = J[4]*J[8] - J[5]*J[7]; \
+  do { const double d_00 = J[4]*J[8] - J[5]*J[7]; \
   const double d_01 = J[5]*J[6] - J[3]*J[8]; \
   const double d_02 = J[3]*J[7] - J[4]*J[6]; \
   const double d_10 = J[2]*J[7] - J[1]*J[8]; \
@@ -145,11 +145,11 @@
   K[5] = d_21 / det; \
   K[6] = d_02 / det; \
   K[7] = d_12 / det; \
-  K[8] = d_22 / det;
+  K[8] = d_22 / det; } while(0)
 
 /// Compute Jacobian inverse K for tensor product prism embedded in R^3 - identical to tet
 #define compute_jacobian_inverse_prism_3d(K, det, J) \
-  const double d_00 = J[4]*J[8] - J[5]*J[7]; \
+  do { const double d_00 = J[4]*J[8] - J[5]*J[7]; \
   const double d_01 = J[5]*J[6] - J[3]*J[8]; \
   const double d_02 = J[3]*J[7] - J[4]*J[6]; \
   const double d_10 = J[2]*J[7] - J[1]*J[8]; \
@@ -167,7 +167,7 @@
   K[5] = d_21 / det; \
   K[6] = d_02 / det; \
   K[7] = d_12 / det; \
-  K[8] = d_22 / det;
+  K[8] = d_22 / det; } while (0)
 
 ///--- Compute facet edge lengths ---
 


### PR DESCRIPTION
avoids having 'multiple const variable declaration' compiler errors when a snippet is used more than once (e.g. interior facets)
