### PR TITLE
Add/fix Jacobian computations for interior facets

### DIFF
--- a/pyop2/pyop2_geometry.h
+++ b/pyop2/pyop2_geometry.h
@@ -27,9 +27,9 @@
 
 /// Compute Jacobian J for interval embedded in R^3
 #define compute_jacobian_interval_3d(J, vertex_coordinates) \
-  J[0] = vertex_coordinates[3][0] - vertex_coordinates[0][0]; \
-  J[1] = vertex_coordinates[4][0] - vertex_coordinates[1][0]; \
-  J[2] = vertex_coordinates[5][0] - vertex_coordinates[2][0];
+  J[0] = vertex_coordinates[1][0] - vertex_coordinates[0][0]; \
+  J[1] = vertex_coordinates[3][0] - vertex_coordinates[2][0]; \
+  J[2] = vertex_coordinates[5][0] - vertex_coordinates[4][0];
 
 /// Compute Jacobian J for triangle embedded in R^2
 #define compute_jacobian_triangle_2d(J, vertex_coordinates) \
@@ -70,6 +70,78 @@
   J[6] = vertex_coordinates[14][0] - vertex_coordinates[12][0]; \
   J[7] = vertex_coordinates[16][0] - vertex_coordinates[12][0]; \
   J[8] = vertex_coordinates[13][0] - vertex_coordinates[12][0];
+
+// Jacobians for interior facets of different sorts
+
+/// Compute Jacobian J for interval embedded in R^1
+#define compute_jacobian_interval_int_1d compute_jacobian_interval_1d
+
+/// Compute Jacobian J for interval embedded in R^2
+#define compute_jacobian_interval_int_2d(J, vertex_coordinates) \
+  J[0] = vertex_coordinates[1][0] - vertex_coordinates[0][0]; \
+  J[1] = vertex_coordinates[5][0] - vertex_coordinates[4][0];
+
+/// Compute Jacobian J for quad embedded in R^2
+#define compute_jacobian_quad_int_2d(J, vertex_coordinates) \
+  J[0] = vertex_coordinates[1] [0] - vertex_coordinates[0][0]; \
+  J[1] = vertex_coordinates[2] [0] - vertex_coordinates[0][0]; \
+  J[2] = vertex_coordinates[9] [0] - vertex_coordinates[8][0]; \
+  J[3] = vertex_coordinates[10][0] - vertex_coordinates[8][0];
+
+/// Compute Jacobian J for quad embedded in R^3
+#define compute_jacobian_quad_int_3d(J, vertex_coordinates) \
+  J[0] = vertex_coordinates[1] [0] - vertex_coordinates[0] [0]; \
+  J[1] = vertex_coordinates[2] [0] - vertex_coordinates[0] [0]; \
+  J[2] = vertex_coordinates[9] [0] - vertex_coordinates[8] [0]; \
+  J[3] = vertex_coordinates[10][0] - vertex_coordinates[8] [0]; \
+  J[4] = vertex_coordinates[17][0] - vertex_coordinates[16][0]; \
+  J[5] = vertex_coordinates[18][0] - vertex_coordinates[16][0];
+
+/// Compute Jacobian J for interval embedded in R^3
+#define compute_jacobian_interval_int_3d(J, vertex_coordinates) \
+  J[0] = vertex_coordinates[1][0] - vertex_coordinates[0][0]; \
+  J[1] = vertex_coordinates[5][0] - vertex_coordinates[4][0]; \
+  J[2] = vertex_coordinates[9][0] - vertex_coordinates[8][0];
+
+/// Compute Jacobian J for triangle embedded in R^2
+#define compute_jacobian_triangle_int_2d(J, vertex_coordinates) \
+  J[0] = vertex_coordinates[1][0] - vertex_coordinates[0][0]; \
+  J[1] = vertex_coordinates[2][0] - vertex_coordinates[0][0]; \
+  J[2] = vertex_coordinates[7][0] - vertex_coordinates[6][0]; \
+  J[3] = vertex_coordinates[8][0] - vertex_coordinates[6][0];
+
+/// Compute Jacobian J for triangle embedded in R^3
+#define compute_jacobian_triangle_int_3d(J, vertex_coordinates) \
+  J[0] = vertex_coordinates[1] [0] - vertex_coordinates[0] [0]; \
+  J[1] = vertex_coordinates[2] [0] - vertex_coordinates[0] [0]; \
+  J[2] = vertex_coordinates[7] [0] - vertex_coordinates[6] [0]; \
+  J[3] = vertex_coordinates[8] [0] - vertex_coordinates[6] [0]; \
+  J[4] = vertex_coordinates[13][0] - vertex_coordinates[12][0]; \
+  J[5] = vertex_coordinates[14][0] - vertex_coordinates[12][0];
+
+/// Compute Jacobian J for tetrahedron embedded in R^3
+#define compute_jacobian_tetrahedron_int_3d(J, vertex_coordinates) \
+  J[0] = vertex_coordinates[1] [0] - vertex_coordinates[0] [0]; \
+  J[1] = vertex_coordinates[2] [0] - vertex_coordinates[0] [0]; \
+  J[2] = vertex_coordinates[3] [0] - vertex_coordinates[0] [0]; \
+  J[3] = vertex_coordinates[9] [0] - vertex_coordinates[8] [0]; \
+  J[4] = vertex_coordinates[10][0] - vertex_coordinates[8] [0]; \
+  J[5] = vertex_coordinates[11][0] - vertex_coordinates[8] [0]; \
+  J[6] = vertex_coordinates[17][0] - vertex_coordinates[16][0]; \
+  J[7] = vertex_coordinates[18][0] - vertex_coordinates[16][0]; \
+  J[8] = vertex_coordinates[19][0] - vertex_coordinates[16][0];
+
+/// Compute Jacobian J for tensor product prism embedded in R^3
+#define compute_jacobian_prism_int_3d(J, vertex_coordinates) \
+  J[0] = vertex_coordinates[2] [0] - vertex_coordinates[0] [0]; \
+  J[1] = vertex_coordinates[4] [0] - vertex_coordinates[0] [0]; \
+  J[2] = vertex_coordinates[1] [0] - vertex_coordinates[0] [0]; \
+  J[3] = vertex_coordinates[14][0] - vertex_coordinates[12][0]; \
+  J[4] = vertex_coordinates[16][0] - vertex_coordinates[12][0]; \
+  J[5] = vertex_coordinates[13][0] - vertex_coordinates[12][0]; \
+  J[6] = vertex_coordinates[26][0] - vertex_coordinates[24][0]; \
+  J[7] = vertex_coordinates[28][0] - vertex_coordinates[24][0]; \
+  J[8] = vertex_coordinates[25][0] - vertex_coordinates[24][0];
 
 //--- Computation of Jacobian inverses ---
 


### PR DESCRIPTION
I've cherry-picked this from the extruded facet branch.  This commit has nothing to do with extruded meshes, and simply adds separate Jacobian calculations for interior facet integrals (which are required since the coordinates for the two cells are interleaved).  The initial three-line edit is an unrelated bugfix.

Obviously this code needs corresponding FFC changes to actually use the new functions; that's on the way, but this can be merged immediately.
