### PR TITLE
Make par_loops properly collective again

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3280,20 +3280,17 @@ class ParLoop(LazyComputation):
         """Executes the kernel over all members of the iteration space."""
         self.halo_exchange_begin()
         self.maybe_set_dat_dirty()
-        self._compute_if_not_empty(self.it_space.iterset.core_part)
+        self._compute(self.it_space.iterset.core_part)
         self.halo_exchange_end()
-        self._compute_if_not_empty(self.it_space.iterset.owned_part)
+        self._compute(self.it_space.iterset.owned_part)
         self.reduction_begin()
         if self.needs_exec_halo:
-            self._compute_if_not_empty(self.it_space.iterset.exec_part)
+            self._compute(self.it_space.iterset.exec_part)
         self.reduction_end()
         self.maybe_set_halo_update_needed()
         self.assemble()
 
-    def _compute_if_not_empty(self, part):
-        if part.size > 0:
-            self._compute(part)
-
+    @collective
     def _compute(self, part):
         """Executes the kernel over all members of a MPI-part of the iteration space."""
         raise RuntimeError("Must select a backend")

--- a/pyop2/cuda.py
+++ b/pyop2/cuda.py
@@ -772,6 +772,9 @@ class ParLoop(op2.ParLoop):
                     'WARPSIZE': 32}
 
     def _compute(self, part):
+        if part.size == 0:
+            # Return before plan call if no computation should occur
+            return
         arglist = [np.int32(part.size), np.int32(part.offset)]
         config = self.launch_configuration(part)
         config['subset'] = False

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -39,6 +39,7 @@ from textwrap import dedent
 import base
 import compilation
 from base import *
+from mpi import collective
 from configuration import configuration
 from utils import as_tuple
 
@@ -545,6 +546,7 @@ class JITModule(base.JITModule):
         self._args = args
         self._direct = kwargs.get('direct', False)
 
+    @collective
     def __call__(self, *args, **kwargs):
         argtypes = kwargs.get('argtypes', None)
         restype = kwargs.get('restype', None)
@@ -554,6 +556,7 @@ class JITModule(base.JITModule):
     def _wrapper_name(self):
         return 'wrap_%s' % self._kernel.name
 
+    @collective
     def compile(self, argtypes=None, restype=None):
         if hasattr(self, '_fun'):
             self._fun.argtypes = argtypes

--- a/pyop2/opencl.py
+++ b/pyop2/opencl.py
@@ -659,6 +659,9 @@ class ParLoop(device.ParLoop):
             return {'partition_size': self._i_partition_size()}
 
     def _compute(self, part):
+        if part.size == 0:
+            # Return before plan call if no computation should occur
+            return
         conf = self.launch_configuration()
         conf['subset'] = isinstance(part.set, Subset)
 


### PR DESCRIPTION
On CPUs, code compilation is now a collective operation (we only build
the code on rank zero).  As a result, we can't short circuit
computations for zero-sized sets since we may be left with an empty code
cache.
