### PR TITLE
fix jacobians for extruded interval cells

### DIFF
--- a/pyop2/pyop2_geometry.h
+++ b/pyop2/pyop2_geometry.h
@@ -11,19 +11,19 @@
 
 /* Compute Jacobian J for quad embedded in R^2 */
 #define compute_jacobian_quad_2d(J, vertex_coordinates) \
-  J[0] = vertex_coordinates[1][0] - vertex_coordinates[0][0]; \
-  J[1] = vertex_coordinates[2][0] - vertex_coordinates[0][0]; \
-  J[2] = vertex_coordinates[5][0] - vertex_coordinates[4][0]; \
-  J[3] = vertex_coordinates[6][0] - vertex_coordinates[4][0];
+  J[0] = vertex_coordinates[2][0] - vertex_coordinates[0][0]; \
+  J[1] = vertex_coordinates[1][0] - vertex_coordinates[0][0]; \
+  J[2] = vertex_coordinates[6][0] - vertex_coordinates[4][0]; \
+  J[3] = vertex_coordinates[5][0] - vertex_coordinates[4][0];
 
 /* Compute Jacobian J for quad embedded in R^3 */
 #define compute_jacobian_quad_3d(J, vertex_coordinates) \
-  J[0] = vertex_coordinates[1] [0] - vertex_coordinates[0][0]; \
-  J[1] = vertex_coordinates[2] [0] - vertex_coordinates[0][0]; \
-  J[2] = vertex_coordinates[5] [0] - vertex_coordinates[4][0]; \
-  J[3] = vertex_coordinates[6] [0] - vertex_coordinates[4][0]; \
-  J[4] = vertex_coordinates[9] [0] - vertex_coordinates[8][0]; \
-  J[5] = vertex_coordinates[10][0] - vertex_coordinates[8][0];
+  J[0] = vertex_coordinates[2] [0] - vertex_coordinates[0][0]; \
+  J[1] = vertex_coordinates[1] [0] - vertex_coordinates[0][0]; \
+  J[2] = vertex_coordinates[6] [0] - vertex_coordinates[4][0]; \
+  J[3] = vertex_coordinates[5] [0] - vertex_coordinates[4][0]; \
+  J[4] = vertex_coordinates[10] [0] - vertex_coordinates[8][0]; \
+  J[5] = vertex_coordinates[9][0] - vertex_coordinates[8][0];
 
 /* Compute Jacobian J for interval embedded in R^3 */
 #define compute_jacobian_interval_3d(J, vertex_coordinates) \
@@ -83,19 +83,19 @@
 
 /* Compute Jacobian J for quad embedded in R^2 */
 #define compute_jacobian_quad_int_2d(J, vertex_coordinates) \
-  J[0] = vertex_coordinates[1] [0] - vertex_coordinates[0][0]; \
-  J[1] = vertex_coordinates[2] [0] - vertex_coordinates[0][0]; \
-  J[2] = vertex_coordinates[9] [0] - vertex_coordinates[8][0]; \
-  J[3] = vertex_coordinates[10][0] - vertex_coordinates[8][0];
+  J[0] = vertex_coordinates[2] [0] - vertex_coordinates[0][0]; \
+  J[1] = vertex_coordinates[1] [0] - vertex_coordinates[0][0]; \
+  J[2] = vertex_coordinates[10] [0] - vertex_coordinates[8][0]; \
+  J[3] = vertex_coordinates[9][0] - vertex_coordinates[8][0];
 
 /* Compute Jacobian J for quad embedded in R^3 */
 #define compute_jacobian_quad_int_3d(J, vertex_coordinates) \
-  J[0] = vertex_coordinates[1] [0] - vertex_coordinates[0] [0]; \
-  J[1] = vertex_coordinates[2] [0] - vertex_coordinates[0] [0]; \
-  J[2] = vertex_coordinates[9] [0] - vertex_coordinates[8] [0]; \
-  J[3] = vertex_coordinates[10][0] - vertex_coordinates[8] [0]; \
-  J[4] = vertex_coordinates[17][0] - vertex_coordinates[16][0]; \
-  J[5] = vertex_coordinates[18][0] - vertex_coordinates[16][0];
+  J[0] = vertex_coordinates[2] [0] - vertex_coordinates[0] [0]; \
+  J[1] = vertex_coordinates[1] [0] - vertex_coordinates[0] [0]; \
+  J[2] = vertex_coordinates[10] [0] - vertex_coordinates[8] [0]; \
+  J[3] = vertex_coordinates[9][0] - vertex_coordinates[8] [0]; \
+  J[4] = vertex_coordinates[18][0] - vertex_coordinates[16][0]; \
+  J[5] = vertex_coordinates[17][0] - vertex_coordinates[16][0];
 
 /* Compute Jacobian J for interval embedded in R^3 */
 #define compute_jacobian_interval_int_3d(J, vertex_coordinates) \


### PR DESCRIPTION
Locally, vertex numbering is

```
13
02
```

`J[0]` should be given by `vertex_coordinates[2][0] - vertex_coordinates[0][0]`, etc.
