### PR TITLE
improve pyop2 build instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,11 +84,6 @@ On a Debian-based system (Ubuntu, Mint, etc.) install them by running::
   sudo apt-get install -y build-essential python-dev git-core mercurial \
   cmake cmake-curses-gui python-pip swig
 
-**Note:** You may find the version of pip this installs is too old, in
- which case you can tell pip to upgrade itself::
-
-   sudo pip install pip
-
 Dependencies
 ------------
 


### PR DESCRIPTION
need to clarify where sudo goes in pip lines, particularly where petsc options are passed.

Suggest to provide two versions of each line, a sudo one and a --user one.
