### PR TITLE
A couple of consequential fixes

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1852,7 +1852,10 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
 
         if configuration['lazy_evaluation']:
             _trace.evaluate(self._cow_parloop.reads, self._cow_parloop.writes)
-            _trace._trace.remove(self._cow_parloop)
+            try:
+                _trace._trace.remove(self._cow_parloop)
+            except ValueError:
+                return
 
         self._cow_parloop._run()
 
@@ -3232,7 +3235,7 @@ class Mat(SetAssociated):
         """
 
         return (self._sparsity.nz + self._sparsity.onz) \
-            * self.dtype.itemsize * np.prod(self._sparsity.dims)
+            * self.dtype.itemsize * np.sum(np.prod(self._sparsity.dims))
 
     def __iter__(self):
         """Yield self when iterated over."""

--- a/pyop2/petsc_base.py
+++ b/pyop2/petsc_base.py
@@ -396,12 +396,14 @@ class Mat(base.Mat, CopyOnWrite):
         if not hasattr(self, '_array'):
             self._init()
         base._trace.evaluate(set([self]), set())
+        self._assemble()
         return self._array
 
     @property
     @modifies
     def values(self):
         base._trace.evaluate(set([self]), set())
+        self._assemble()
         return self.handle[:, :]
 
     @property


### PR DESCRIPTION
- It turns out lazy sometimes evaluates the CoW copy early. That's fine, but we have to take that into account.
- Touching .values or .array needs to force matrix assembly.
