### PR TITLE
Only preprocess kernel code on device

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3445,7 +3445,7 @@ class Kernel(Cached):
         if self._initialized:
             return
         self._name = name or "kernel_%d" % Kernel._globalcount
-        self._code = preprocess(self._ast_to_c(code, opts), include_dirs)
+        self._code = self._ast_to_c(code, opts)
         Kernel._globalcount += 1
         # Record used optimisations
         self._opt_is_padded = opts.get('ap', False)

--- a/pyop2/device.py
+++ b/pyop2/device.py
@@ -50,6 +50,12 @@ class Kernel(base.Kernel):
         ast_handler.plan_gpu()
         return ast.gencode()
 
+    def __init__(self, code, name, opts={}, include_dirs=[]):
+        if self._initialized:
+            return
+        self._code = preprocess(self._ast_to_c(code, opts), include_dirs)
+        super(Kernel, self).__init__(self._code, name, opts=opts, include_dirs=include_dirs)
+
 
 class Arg(base.Arg):
 


### PR DESCRIPTION
It's only on the device where we need to run pycparser on the kernel
code, which is what necessitates preprocessing it.  We can speed up host
execution a little by never preprocessing the code.
