### PR TITLE
When running with openmp enabled, petsc must have been configured with threading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,14 @@ Then install PETSc_ via ``pip`` ::
   unset PETSC_DIR
   unset PETSC_ARCH
 
+.. note::
+
+   If you intend to run PyOP2's OpenMP backend, you should
+   additionally pass the following options to the PETSc configure
+   stage ::
+
+     --with-threadcomm --with-openmp --with-pthreadclasses
+
 If you built PETSc_ using ``pip``, ``PETSC_DIR`` and ``PETSC_ARCH``
 should be left unset when building petsc4py_.
 


### PR DESCRIPTION
PETSc does a bunch of error checking/stack frame registration (more when compiled in debug mode).  These checks are /not/ thread safe unless PETSc has been compiled with threading enabled (`--with-threadcomm --with-pthreadclasses --with-openmp`).  This can cause hangs/segfaults at weird places in the code because memory has been overwritten in strange places.

We should probably update docs appropriately (and ask for appropriate petsc-3.4 packages?)
