### PR TITLE
Treat zeroing Mats and Dats as a modification

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -43,7 +43,8 @@ from hashlib import md5
 
 from configuration import configuration
 from caching import Cached, ObjectCached
-from versioning import Versioned, modifies, modifies_argn, CopyOnWrite, shallow_copy
+from versioning import Versioned, modifies, modifies_argn, CopyOnWrite, \
+    shallow_copy, zeroes
 from exceptions import *
 from utils import *
 from backends import _make_object
@@ -1776,6 +1777,7 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
         """Indictate whether this Dat requires a halo update"""
         self._needs_halo_update = val
 
+    @zeroes
     @collective
     def zero(self):
         """Zero the data associated with this :class:`Dat`"""
@@ -1789,8 +1791,6 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
                             pred=["static", "inline"])
             self._zero_kernel = _make_object('Kernel', k, 'zero')
         par_loop(self._zero_kernel, self.dataset.set, self(WRITE))
-
-        self._version_set_zero()
 
     @modifies_argn(0)
     @collective

--- a/pyop2/petsc_base.py
+++ b/pyop2/petsc_base.py
@@ -46,7 +46,7 @@ import base
 from base import *
 from backends import _make_object
 from logger import debug, warning
-from versioning import CopyOnWrite, modifies
+from versioning import CopyOnWrite, modifies, zeroes
 import mpi
 from mpi import collective
 
@@ -309,12 +309,12 @@ class Mat(base.Mat, CopyOnWrite):
         vwr = PETSc.Viewer().createBinary(filename, PETSc.Viewer.Mode.WRITE)
         self.handle.view(vwr)
 
+    @zeroes
     @collective
     def zero(self):
         """Zero the matrix."""
         base._trace.evaluate(set(), set([self]))
         self.handle.zeroEntries()
-        self._version_set_zero()
 
     @modifies
     @collective

--- a/pyop2/versioning.py
+++ b/pyop2/versioning.py
@@ -115,6 +115,19 @@ def modifies(method, self, *args, **kwargs):
     return retval
 
 
+@decorator
+def zeroes(method, self, *args, **kwargs):
+    "Decorator for methods that zero their instance's data"
+
+    _force_copies(self)
+
+    retval = method(self, *args, **kwargs)
+
+    self._version_set_zero()
+
+    return retval
+
+
 def modifies_argn(n):
     """Decorator for a method that modifies its nth argument
 


### PR DESCRIPTION
Zeroing a Mat or a Dat should trigger copy on write operations.
