### PR TITLE
Fix identification of inner loops

### DIFF
--- a/pyop2/coffee/ast_vectorizer.py
+++ b/pyop2/coffee/ast_vectorizer.py
@@ -452,7 +452,7 @@ def inner_loops(node):
     def find_iloops(node, loops):
         if isinstance(node, Perfect):
             return False
-        elif isinstance(node, Block):
+        elif isinstance(node, (Block, Root)):
             return any([find_iloops(s, loops) for s in node.children])
         elif isinstance(node, For):
             found = find_iloops(node.children[0], loops)


### PR DESCRIPTION
Fix idiotic bug when trying to identify inner loops in an ast
