### PR TITLE
make Globals more like Dats

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2649,7 +2649,7 @@ class Global(DataCarrier, _EmptyDataMixin):
 
     def duplicate(self):
         """Return a deep copy of self."""
-        return type(self)(self.dim, data=np.copy(self._data),
+        return type(self)(self.dim, data=np.copy(self.data_ro),
                           dtype=self.dtype, name=self.name)
 
 


### PR DESCRIPTION
Implement trivial indexing and duplication on Global so it can be used
in places where a Dat is used. This is needed to make the Real
function space work in Firedrake.
