### PR TITLE
No subprocess call

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -114,13 +114,21 @@ class Compiler(object):
                                 log.write(" ".join(cc))
                                 log.write("\n\n")
                                 try:
-                                    subprocess.check_call(cc, stderr=err, stdout=log)
-                                except Exception as e:
+                                    if configuration['no_fork_available']:
+                                        cc += ["2>", errfile, ">", logfile]
+                                        cmd = " ".join(cc)
+                                        status = os.system(cmd)
+                                        if status != 0:
+                                            raise subprocess.CalledProcessError(status, cmd)
+                                    else:
+                                        subprocess.check_call(cc, stderr=err,
+                                                              stdout=log)
+                                except subprocess.CalledProcessError as e:
                                     raise CompilationError(
-                                        """Caught exception "%s".
+                                        """Command "%s" return error status %d.
 Unable to compile code
 Compile log in %s
-Compile errors in %s""" % (e.message, logfile, errfile))
+Compile errors in %s""" % (e.cmd, e.returncode, logfile, errfile))
                     else:
                         cc = [self._cc] + self._cppargs + \
                              ['-c', oname, cname]
@@ -134,14 +142,28 @@ Compile errors in %s""" % (e.message, logfile, errfile))
                                 log.write(" ".join(ld))
                                 log.write("\n\n")
                                 try:
-                                    subprocess.check_call(cc, stderr=err, stdout=log)
-                                    subprocess.check_call(ld, stderr=err, stdout=log)
-                                except Exception as e:
+                                    if configuration['no_fork_available']:
+                                        cc += ["2>", errfile, ">", logfile]
+                                        ld += ["2>", errfile, ">", logfile]
+                                        cccmd = " ".join(cc)
+                                        ldcmd = " ".join(ld)
+                                        status = os.system(cccmd)
+                                        if status != 0:
+                                            raise subprocess.CalledProcessError(status, cccmd)
+                                        status = os.system(ldcmd)
+                                        if status != 0:
+                                            raise subprocess.CalledProcessError(status, ldcmd)
+                                    else:
+                                        subprocess.check_call(cc, stderr=err,
+                                                              stdout=log)
+                                        subprocess.check_call(ld, stderr=err,
+                                                              stdout=log)
+                                except subprocess.CalledProcessError as e:
                                     raise CompilationError(
-                                        """Caught exception "%s".
+                                        """Command "%s" return error status %d.
 Unable to compile code
 Compile log in %s
-Compile errors in %s""" % (e.message, logfile, errfile))
+Compile errors in %s""" % (e.cmd, e.returncode, logfile, errfile))
                     # Atomically ensure soname exists
                     os.rename(tmpname, soname)
             # Wait for compilation to complete

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -77,6 +77,7 @@ class Configuration(object):
         "cache_dir": ("PYOP2_CACHE_DIR", str,
                       os.path.join(gettempdir(),
                                    "pyop2-cache-uid%s" % os.getuid())),
+        "no_fork_available": ("PYOP2_NO_FORK_AVAILABLE", bool, False),
         "print_cache_size": ("PYOP2_PRINT_CACHE_SIZE", bool, False),
         "print_summary": ("PYOP2_PRINT_SUMMARY", bool, False),
         "profiling": ("PYOP2_PROFILING", bool, False),


### PR DESCRIPTION
Add option to use os.system rather than subprocess.check_call when compiling code.  Seems to be more robust to failures on ARCHER.
