### PR TITLE
add mpi4py to install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,7 @@ subsystem:
 * decorator 
 * numpy >= 1.6 
 * networkx
+* mpi4py >= 1.3.1
 
 PETSc. We require very recent versions of PETSc so you will need to follow the specific instructions given below to install the right version.
 
@@ -156,7 +157,7 @@ On a Debian-based system (Ubuntu, Mint, etc.) install core packages::
 
 Install dependencies via ``pip``::
 
-  sudo pip install "Cython>=0.17" decorator "numpy>=1.6" networkx
+  sudo pip install "Cython>=0.17" decorator "numpy>=1.6" networkx "mpi4py>=1.3.1"
 
 .. note::
 


### PR DESCRIPTION
Should be uncontroversial, but does it belong here or in the 'testing dependencies' part?

The >=1.3.1 is following the requirements-minimal.txt... I assume this still applies?

```
atm112@ubuntu:~/local/PyOP2$ make test
cd test; py.test unit --backend=sequential
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/_pytest/config.py", line 543, in importconftest
    mod = conftestpath.pyimport()
  File "/usr/local/lib/python2.7/dist-packages/py/_path/local.py", line 642, in pyimport
    __import__(modname)
  File "/home/atm112/local/PyOP2/test/conftest.py", line 40, in <module>
    from pyop2 import op2
  File "/home/atm112/local/PyOP2/pyop2/__init__.py", line 9, in <module>
    from op2 import *
  File "/home/atm112/local/PyOP2/pyop2/op2.py", line 38, in <module>
    import backends
  File "/home/atm112/local/PyOP2/pyop2/backends.py", line 41, in <module>
    from logger import warning
  File "/home/atm112/local/PyOP2/pyop2/logger.py", line 38, in <module>
    from mpi import MPI
  File "/home/atm112/local/PyOP2/pyop2/mpi.py", line 37, in <module>
    from mpi4py import MPI as _MPI
ImportError: No module named mpi4py
ERROR: could not load /home/atm112/local/PyOP2/test/conftest.py

Makefile:50: recipe for target 'unit_sequential' failed
make: *** [unit_sequential] Error 4
```
