### PR TITLE
Vec state

### DIFF
--- a/pyop2/petsc_base.py
+++ b/pyop2/petsc_base.py
@@ -93,7 +93,14 @@ class Dat(base.Dat):
         if not hasattr(self, '_vec'):
             size = (self.dataset.size * self.cdim, None)
             self._vec = PETSc.Vec().createWithArray(acc(self), size=size)
+        # PETSc Vecs have a state counter and cache norm computations
+        # to return immediately if the state counter is unchanged.
+        # Since we've updated the data behind their back, we need to
+        # change that state counter.  The easiest is to do some
+        # pointer shuffling here.
+        self._vec.placeArray(acc(self))
         yield self._vec
+        self._vec.resetArray()
         if not readonly:
             self.needs_halo_update = True
 

--- a/test/unit/test_petsc.py
+++ b/test/unit/test_petsc.py
@@ -52,7 +52,6 @@ class TestPETSc:
         op2.MPI.comm = petsc4py.PETSc.Sys.getDefaultComm()
         assert isinstance(op2.MPI.comm, mpi4py.MPI.Comm)
 
-    @pytest.mark.xfail
     def test_vec_norm_changes(self, backend, skip_cuda, skip_opencl):
         s = op2.Set(1)
         d = op2.Dat(s)


### PR DESCRIPTION
PETSc Vecs cache some state, we need to invalidate when returning a context manager reference to them.
