### PR TITLE
Remove bad instruction from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,6 @@ errors before committing and also calls `flake8` on your changed files. In the
 ```
 git config --local core.whitespace "space-before-tab, tab-in-indent, trailing-space, tabwidth=4"
 wget https://gist.github.com/kynan/d233073b66e860c41484/raw/pre-commit
-mv .git/hooks/pre-commit.sample .git/hooks/pre-commit
 chmod +x pre-commit
 ```
 


### PR DESCRIPTION
It doesn't make sense to overwrite the thing we just downloaded with
the sample hook.