### PR TITLE
Fix skipping CUDA for TestDat and TestMatrices

### DIFF
--- a/test/unit/test_dats.py
+++ b/test/unit/test_dats.py
@@ -108,7 +108,7 @@ class TestDat:
         with pytest.raises(NotImplementedError):
             mdat.copy(op2.MixedDat([s, s]), subset=op2.Subset(s, []))
 
-    @pytest.mark.skipif('config.getvalue("backend")[0] not in ["cuda", "opencl"]')
+    @pytest.mark.skipif('config.getvalue("backend") and config.getvalue("backend")[0] not in ["cuda", "opencl"]')
     def test_copy_works_device_to_device(self, backend, d1):
         d2 = op2.Dat(d1)
 

--- a/test/unit/test_matrices.py
+++ b/test/unit/test_matrices.py
@@ -762,7 +762,7 @@ class TestMatrices:
         """Check that the matrix uses the amount of memory we expect."""
         assert mat.nbytes == 14 * 8
 
-    @pytest.mark.xfail('config.getvalue("backend")[0] == "cuda"')
+    @pytest.mark.xfail('config.getvalue("backend") and config.getvalue("backend")[0] == "cuda"')
     def test_set_diagonal(self, backend, x, mat):
         mat.zero()
         mat.set_diagonal(x)


### PR DESCRIPTION
The idiom for skipping cuda seems to have changed but these two places still
use the old way which now crashes when you run with the CUDA backend.

The crash looked like this:
```
Error evaluating 'xfail' expression
    config.getvalue("backend")[0] == "cuda"
TypeError: 'NoneType' object has no attribute '__getitem__'
```

I couldn't work out exactly why this was happening but I think the rest of the tests
now use the skip_x fixtures so we can use them instead.
