### PR TITLE
The CUDA Mat should implement duplicate

### DIFF
--- a/pyop2/cuda.py
+++ b/pyop2/cuda.py
@@ -366,6 +366,12 @@ class Mat(DeviceDataMixin, op2.Mat):
         self._lmadata.fill(0)
         self._version_set_zero()
 
+    def duplicate(self):
+        other = Mat(self.sparsity)
+        base._trace.evaluate(set([self]), set([self]))
+        setattr(other, '__csrdata', self._csrdata.copy())
+        return other
+
 
 class Const(DeviceDataMixin, op2.Const):
 


### PR DESCRIPTION
The CUDA implmentation of Mat does not seem to end
up with a definition of duplicate. It looks like
the OpenCL gets its from petsc_base.Mat so we should
probably be getting ours from there to.