### PR TITLE
Update device and host to use ASTKernel subclasses

### DIFF
--- a/pyop2/device.py
+++ b/pyop2/device.py
@@ -35,7 +35,7 @@ import base
 from base import *
 
 from coffee.base import Node
-from coffee.plan import ASTKernel
+from coffee.plan import ASTKernelGPU
 
 from mpi import collective
 
@@ -48,8 +48,8 @@ class Kernel(base.Kernel):
         if not isinstance(ast, Node):
             return ast
         self._ast = ast
-        ast_handler = ASTKernel(ast)
-        ast_handler.plan_gpu()
+        ast_handler = ASTKernelGPU(ast)
+        ast_handler.plan(opts)
         return ast.gencode()
 
     def __init__(self, code, name, opts={}, include_dirs=[]):

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -44,7 +44,7 @@ from configuration import configuration
 from utils import as_tuple
 
 from coffee.base import Node
-from coffee.plan import ASTKernel
+from coffee.plan import ASTKernelCPU
 import coffee.plan
 from coffee.vectorizer import vect_roundup
 
@@ -59,8 +59,8 @@ class Kernel(base.Kernel):
             self._applied_ap = False
             return ast
         self._ast = ast
-        ast_handler = ASTKernel(ast, self._include_dirs)
-        ast_handler.plan_cpu(opts)
+        ast_handler = ASTKernelCPU(ast, self._include_dirs)
+        ast_handler.plan(opts)
         self._applied_blas = ast_handler.blas
         self._applied_ap = ast_handler.ap
         return ast_handler.gencode()


### PR DESCRIPTION
Use ASTKernel subclasses so COFFEE can generate backend specific code.