### PR TITLE
travis: Install requirements one by one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,15 @@ before_install:
     cmake cmake-curses-gui libmed1 gmsh python-pip libhdf5-openmpi-dev \
     libopenmpi-dev openmpi-bin libblas-dev liblapack-dev gfortran \
     triangle-bin cython"
-  - pip install -r requirements-minimal.txt
+# Force installation of requirements IN THE ORDER WE SPECIFIED!  AAAARGH.
+  - "xargs -l1 pip install --allow-external mpi4py --allow-unverified mpi4py \
+       --allow-external petsc --allow-unverified petsc \
+       --allow-external petsc4py  --allow-unverified petsc4py \
+       < requirements-minimal.txt"
   - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install argparse ordereddict; fi
 install: "python setup.py develop"
 # command to run tests
 script:
-  - "flake8"
+  - "make lint"
   - "py.test test --backend=sequential -v --tb=native"
   - "py.test test --backend=openmp -v --tb=native"

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,10 +1,3 @@
---allow-external mpi4py
---allow-unverified mpi4py
---allow-external petsc
---allow-unverified petsc
---allow-external petsc4py
---allow-unverified petsc4py
-
 numpy>=1.9.1
 Cython>=0.17
 pytest>=2.3
@@ -13,5 +6,5 @@ pycparser>=2.10
 mpi4py>=1.3.1
 h5py>=2.0.0
 git+https://bitbucket.org/mapdes/petsc.git@firedrake#egg=petsc
-git+https://bitbucket.org/mapdes/petsc4py.git@firedrake#egg=petsc4py
+--no-deps git+https://bitbucket.org/mapdes/petsc4py.git@firedrake#egg=petsc4py
 git+https://github.com/coneoproject/COFFEE#egg=COFFEE-dev


### PR DESCRIPTION
Recent pip updates no longer install packages in requirements.txt in the
order they're specified.  But some of the packages we use depend on
previously having installed other requirements.  Fudge around this
particular Python packaging disaster by passing each line of the
requirements file individually to pip via xargs.  This does mean the
only things we can put in requirements files are package requirements,
oh well.