### PR TITLE
Simplify and improve code generation

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -180,6 +180,9 @@ class Access(object):
     def __init__(self, mode):
         self._mode = mode
 
+    def __eq__(self, other):
+        return self._mode == other._mode
+
     def __str__(self):
         return "OP2 Access: %s" % self._mode
 

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3690,10 +3690,7 @@ class Kernel(Cached):
     def _ast_to_c(self, ast, opts={}):
         """Transform an Abstract Syntax Tree representing the kernel into a
         string of C code."""
-        if isinstance(ast, Node):
-            self._ast = ast
-            return ast.gencode()
-        return ast
+        return ast.gencode()
 
     def __init__(self, code, name, opts={}, include_dirs=[], headers=[],
                  user_code=""):
@@ -3705,11 +3702,12 @@ class Kernel(Cached):
         # Record used optimisations
         self._opts = opts
         self._applied_blas = False
-        self._applied_ap = False
         self._include_dirs = include_dirs
         self._headers = headers
         self._user_code = user_code
-        self._code = self._ast_to_c(code, opts)
+        self._code = code
+        # If an AST is provided, code generation is deferred
+        self._ast, self._code = (code, None) if isinstance(code, Node) else (None, code)
         self._initialized = True
 
     @property
@@ -3721,13 +3719,16 @@ class Kernel(Cached):
     def code(self):
         """String containing the c code for this kernel routine. This
         code must conform to the OP2 user kernel API."""
+        if not self._code:
+            self._code = self._ast_to_c(self._ast, self._opts)
         return self._code
 
     def __str__(self):
         return "OP2 Kernel: %s" % self._name
 
     def __repr__(self):
-        return 'Kernel("""%s""", %r)' % (self._code, self._name)
+        code = self._ast.gencode() if self._ast else self._code
+        return 'Kernel("""%s""", %r)' % (code, self._name)
 
 
 class JITModule(Cached):

--- a/pyop2/device.py
+++ b/pyop2/device.py
@@ -34,7 +34,6 @@
 import base
 from base import *
 
-from coffee.base import Node
 from coffee.plan import ASTKernel
 
 from mpi import collective
@@ -45,9 +44,6 @@ class Kernel(base.Kernel):
     def _ast_to_c(self, ast, opts={}):
         """Transform an Abstract Syntax Tree representing the kernel into a
         string of code (C syntax) suitable to GPU execution."""
-        if not isinstance(ast, Node):
-            return ast
-        self._ast = ast
         ast_handler = ASTKernel(ast)
         ast_handler.plan_gpu()
         return ast.gencode()

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -253,7 +253,6 @@ class Arg(base.Arg):
         ret = []
         rbs, cbs = self.data.sparsity[i, j].dims[0][0]
         rdim = rbs * nrows
-        cdim = cbs * ncols
         addto_name = buf_name
         addto = 'MatSetValuesLocal'
         if self.data._is_vector_field:
@@ -883,18 +882,16 @@ class JITModule(base.JITModule):
             if is_facet:
                 mult = 2
             _itspace_loops = '\n'.join(['  ' * n + itspace_loop(n, e*mult) for n, e in enumerate(shape)])
-            _addto_buf_name, _buf_decl_scatter, _buf_scatter = {}, {}, {}
+            _buf_decl_scatter, _buf_scatter = {}, {}
             for count, arg in enumerate(self._args):
                 if not (arg._uses_itspace and arg.access in [WRITE, INC]):
                     continue
-                _buf_scatter_name = ""
                 if arg._is_mat and arg._is_mixed:
                     raise NotImplementedError
                 elif not arg._is_mat:
                     _buf_scatter[arg] = arg.c_buffer_scatter_vec(count, i, j, offsets, _buf_name[arg])
             _buf_decl_scatter = ";\n".join(_buf_decl_scatter.values())
             _buf_scatter = ";\n".join(_buf_scatter.values())
-            _buffer_indices = "[i_0*%d + i_1]" % shape[1] if self._kernel._applied_blas else "[i_0][i_1]"
             _itspace_loop_close = '\n'.join('  ' * n + '}' for n in range(nloops - 1, -1, -1))
             if self._itspace._extruded:
                 _addtos_extruded = ';\n'.join([arg.c_addto(i, j, _buf_name[arg],

--- a/test/unit/test_matrices.py
+++ b/test/unit/test_matrices.py
@@ -795,6 +795,7 @@ class TestMixedMatrices:
                      mat(op2.INC, (mmap[op2.i[0]], mmap[op2.i[1]])),
                      mdat(op2.READ, mmap))
         mat.assemble()
+        mat._force_evaluation()
         return mat
 
     @pytest.fixture


### PR DESCRIPTION
Padding is now entirely supported by COFFEE, so there is no need to pad the buffer arrays in the wrapper code generation anymore.

As a consequence, code generation in host.py is greatly simplified/improved.

Note that code generation from ASTs to C is now postponed until the invocation of the ``compile`` method in ``JITModules``.

This depends on PR #36 in COFFEE.

