### PR TITLE
Loop Fusion

### DIFF
--- a/pyop2/assets/cuda_direct_loop.jinja2
+++ b/pyop2/assets/cuda_direct_loop.jinja2
@@ -92,7 +92,7 @@ __global__ void {{ parloop._stub_name }} (int set_size, int offset
 #define OP2_STRIDE(array, idx) (array)[ {{ launch.op2stride }} * (idx)]
 {% endif %}
 
-{{ parloop.kernel.code }}
+{{ parloop.kernel.code() }}
 
 {% for arg in parloop._all_global_reduction_args -%}
 {{ reduction.reduction_kernel(arg) }}

--- a/pyop2/assets/cuda_indirect_loop.jinja2
+++ b/pyop2/assets/cuda_indirect_loop.jinja2
@@ -246,7 +246,7 @@ __global__ void {{ parloop._stub_name }} (
 {% endif %}
 #define ROUND_UP(bytes) (((bytes) + 15) & ~15)
 
-{{ parloop.kernel.code }}
+{{ parloop.kernel.code() }}
 
 {% for arg in parloop._all_global_reduction_args -%}
 {{ reduction.reduction_kernel(arg) }}

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3721,7 +3721,6 @@ class Kernel(Cached):
         self._include_dirs = include_dirs
         self._headers = headers
         self._user_code = user_code
-        self._code = code
         # If an AST is provided, code generation is deferred
         self._ast, self._code = (code, None) if isinstance(code, Node) else (None, code)
         self._initialized = True
@@ -3731,7 +3730,6 @@ class Kernel(Cached):
         """Kernel name, must match the kernel function name in the code."""
         return self._name
 
-    @property
     def code(self):
         """String containing the c code for this kernel routine. This
         code must conform to the OP2 user kernel API."""

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -64,9 +64,10 @@ class LazyComputation(object):
     """Helper class holding computation to be carried later on.
     """
 
-    def __init__(self, reads, writes):
+    def __init__(self, reads, writes, incs):
         self.reads = set(flatten(reads))
         self.writes = set(flatten(writes))
+        self.incs = set(flatten(incs))
         self._scheduled = False
 
     def enqueue(self):
@@ -3513,7 +3514,7 @@ class Mat(SetAssociated):
 
         Called lazily after user calls :meth:`assemble`"""
         def __init__(self, mat):
-            super(Mat._Assembly, self).__init__(reads=mat, writes=mat)
+            super(Mat._Assembly, self).__init__(reads=mat, writes=mat, incs=mat)
             self._mat = mat
 
         def _run(self):
@@ -3868,7 +3869,8 @@ class ParLoop(LazyComputation):
     def __init__(self, kernel, iterset, *args, **kwargs):
         LazyComputation.__init__(self,
                                  set([a.data for a in args if a.access in [READ, RW]]) | Const._defs,
-                                 set([a.data for a in args if a.access in [RW, WRITE, MIN, MAX, INC]]))
+                                 set([a.data for a in args if a.access in [RW, WRITE, MIN, MAX, INC]]),
+                                 set([a.data for a in args if a.access in [INC]]))
         # INCs into globals need to start with zero and then sum back
         # into the input global at the end.  This has the same number
         # of reductions but means that successive par_loops

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3923,7 +3923,7 @@ class ParLoop(LazyComputation):
 
         self._it_space = self.build_itspace(iterset)
 
-        # Attach semantical information to the kernel's AST
+        # Attach semantic information to the kernel's AST
         if hasattr(self._kernel, '_ast') and self._kernel._ast:
             ast_info = ast_visit(self._kernel._ast, search=ast.FunDecl)
             fundecl = ast_info['search'][ast.FunDecl]

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3930,7 +3930,7 @@ class ParLoop(LazyComputation):
             if len(fundecl) == 1:
                 for arg, f_arg in zip(self._actual_args, fundecl[0].args):
                     if arg._uses_itspace and arg._is_INC:
-                        f_arg.pragma = ast.WRITE
+                        f_arg.pragma = set([ast.WRITE])
 
     def _run(self):
         return self.compute()

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1930,9 +1930,9 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
         """Create the :class:`ParLoop` implementing copy."""
         if not hasattr(self, '_copy_kernel'):
             k = ast.FunDecl("void", "copy",
-                            [ast.Decl(self.ctype, ast.Symbol("*self"),
+                            [ast.Decl("%s*" % self.ctype, ast.Symbol("self"),
                                       qualifiers=["const"]),
-                             ast.Decl(other.ctype, ast.Symbol("*other"))],
+                             ast.Decl("%s*" % other.ctype, ast.Symbol("other"))],
                             body=ast.c_for("n", self.cdim,
                                            ast.Assign(ast.Symbol("other", ("n", )),
                                                       ast.Symbol("self", ("n", ))),
@@ -2029,9 +2029,9 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
         if np.isscalar(other):
             other = _make_object('Global', 1, data=other)
             k = ast.FunDecl("void", name,
-                            [ast.Decl(self.ctype, ast.Symbol("*self"),
+                            [ast.Decl("%s*" % self.ctype, ast.Symbol("self"),
                                       qualifiers=["const"]),
-                             ast.Decl(other.ctype, ast.Symbol("*other"),
+                             ast.Decl("%s*" % other.ctype, ast.Symbol("other"),
                                       qualifiers=["const"]),
                              ast.Decl(self.ctype, ast.Symbol("*ret"))],
                             ast.c_for("n", self.cdim,
@@ -2045,9 +2045,9 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
         else:
             self._check_shape(other)
             k = ast.FunDecl("void", name,
-                            [ast.Decl(self.ctype, ast.Symbol("*self"),
+                            [ast.Decl("%s*" % self.ctype, ast.Symbol("self"),
                                       qualifiers=["const"]),
-                             ast.Decl(other.ctype, ast.Symbol("*other"),
+                             ast.Decl("%s*" % other.ctype, ast.Symbol("other"),
                                       qualifiers=["const"]),
                              ast.Decl(self.ctype, ast.Symbol("*ret"))],
                             ast.c_for("n", self.cdim,
@@ -2071,8 +2071,8 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
         if np.isscalar(other):
             other = _make_object('Global', 1, data=other)
             k = ast.FunDecl("void", name,
-                            [ast.Decl(self.ctype, ast.Symbol("*self")),
-                             ast.Decl(other.ctype, ast.Symbol("*other"),
+                            [ast.Decl("%s*" % self.ctype, ast.Symbol("self")),
+                             ast.Decl("%s*" % other.ctype, ast.Symbol("other"),
                                       qualifiers=["const"])],
                             ast.c_for("n", self.cdim,
                                       ops[op](ast.Symbol("self", ("n", )),
@@ -2083,8 +2083,8 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
             self._check_shape(other)
             quals = ["const"] if self is not other else []
             k = ast.FunDecl("void", name,
-                            [ast.Decl(self.ctype, ast.Symbol("*self")),
-                             ast.Decl(other.ctype, ast.Symbol("*other"),
+                            [ast.Decl("%s*" % self.ctype, ast.Symbol("self")),
+                             ast.Decl("%s*" % other.ctype, ast.Symbol("other"),
                                       qualifiers=quals)],
                             ast.c_for("n", self.cdim,
                                       ops[op](ast.Symbol("self", ("n", )),
@@ -2098,7 +2098,7 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
         ops = {operator.sub: ast.Neg}
         name = "uop_%s" % op.__name__
         k = ast.FunDecl("void", name,
-                        [ast.Decl(self.ctype, ast.Symbol("*self"))],
+                        [ast.Decl("%s*" % self.ctype, ast.Symbol("self"))],
                         ast.c_for("n", self.cdim,
                                   ast.Assign(ast.Symbol("self", ("n", )),
                                              ops[op](ast.Symbol("self", ("n", )))),
@@ -2118,9 +2118,9 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
         ret = _make_object('Global', 1, data=0, dtype=self.dtype)
 
         k = ast.FunDecl("void", "inner",
-                        [ast.Decl(self.ctype, ast.Symbol("*self"),
+                        [ast.Decl("%s*" % self.ctype, ast.Symbol("self"),
                                   qualifiers=["const"]),
-                         ast.Decl(other.ctype, ast.Symbol("*other"),
+                         ast.Decl("%s*" % other.ctype, ast.Symbol("other"),
                                   qualifiers=["const"]),
                          ast.Decl(self.ctype, ast.Symbol("*ret"))],
                         ast.c_for("n", self.cdim,

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3748,6 +3748,9 @@ class Kernel(Cached):
         code = self._ast.gencode() if self._ast else self._code
         return 'Kernel("""%s""", %r)' % (code, self._name)
 
+    def __eq__(self, other):
+        return self.cache_key == other.cache_key
+
 
 class JITModule(Cached):
 

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -448,12 +448,12 @@ class Arg(object):
         return self._is_indirect and self._access is not READ
 
     @property
-    def _is_readonly(self):
+    def _is_read(self):
         return self._access == READ
 
     @property
     def _is_written(self):
-        return not self._is_readonly
+        return not self._is_read
 
     @property
     def _is_indirect_reduction(self):

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -447,6 +447,14 @@ class Arg(object):
         return self._is_indirect and self._access is not READ
 
     @property
+    def _is_readonly(self):
+        return self._access == READ
+
+    @property
+    def _is_written(self):
+        return not self._is_readonly
+
+    @property
     def _is_indirect_reduction(self):
         return self._is_indirect and self._access is INC
 

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1892,10 +1892,10 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
         """Zero the data associated with this :class:`Dat`"""
         if not hasattr(self, '_zero_kernel'):
             k = ast.FunDecl("void", "zero",
-                            [ast.Decl(self.ctype, ast.Symbol("*self"))],
+                            [ast.Decl("%s*" % self.ctype, ast.Symbol("self"))],
                             body=ast.c_for("n", self.cdim,
                                            ast.Assign(ast.Symbol("self", ("n", )),
-                                                      ast.FlatBlock("(%s)0" % self.ctype)),
+                                                      ast.Symbol("(%s)0" % self.ctype)),
                                            pragma=None))
             self._zero_kernel = _make_object('Kernel', k, 'zero')
         par_loop(self._zero_kernel, self.dataset.set, self(WRITE))

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -149,13 +149,19 @@ class ExecutionTrace(object):
             else:
                 comp._scheduled = False
 
-        new_trace = list()
+        to_run, new_trace = list(), list()
         for comp in self._trace:
             if comp._scheduled:
-                comp._run()
+                to_run.append(comp)
             else:
                 new_trace.append(comp)
         self._trace = new_trace
+
+        if configuration['loop_fusion']:
+            from fusion import fuse
+            to_run = fuse('from_trace', to_run, 0)
+        for comp in to_run:
+            comp._run()
 
 
 _trace = ExecutionTrace()

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2020,10 +2020,10 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
                              self.dataset.dim, other.dataset.dim)
 
     def _op(self, other, op):
-        ops = {operator.add: '+',
-               operator.sub: '-',
-               operator.mul: '*',
-               operator.div: '/'}
+        ops = {operator.add: ast.Sum,
+               operator.sub: ast.Sub,
+               operator.mul: ast.Prod,
+               operator.div: ast.Div}
         ret = _make_object('Dat', self.dataset, None, self.dtype)
         name = "binop_%s" % op.__name__
         if np.isscalar(other):
@@ -2036,9 +2036,8 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
                              ast.Decl(self.ctype, ast.Symbol("*ret"))],
                             ast.c_for("n", self.cdim,
                                       ast.Assign(ast.Symbol("ret", ("n", )),
-                                                 ast.BinExpr(ast.Symbol("self", ("n", )),
-                                                             ast.Symbol("other", ("0", )),
-                                                             op=ops[op])),
+                                                 ops[op](ast.Symbol("self", ("n", )),
+                                                         ast.Symbol("other", ("0", )))),
                                       pragma=None))
 
             k = _make_object('Kernel', k, name)
@@ -2052,9 +2051,8 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
                              ast.Decl(self.ctype, ast.Symbol("*ret"))],
                             ast.c_for("n", self.cdim,
                                       ast.Assign(ast.Symbol("ret", ("n", )),
-                                                 ast.BinExpr(ast.Symbol("self", ("n", )),
-                                                             ast.Symbol("other", ("n", )),
-                                                             op=ops[op])),
+                                                 ops[op](ast.Symbol("self", ("n", )),
+                                                         ast.Symbol("other", ("n", )))),
                                       pragma=None))
 
             k = _make_object('Kernel', k, name)

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2048,7 +2048,7 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
                                       qualifiers=["const"]),
                              ast.Decl("%s*" % other.ctype, ast.Symbol("other"),
                                       qualifiers=["const"]),
-                             ast.Decl(self.ctype, ast.Symbol("*ret"))],
+                             ast.Decl("%s*" % self.ctype, ast.Symbol("ret"))],
                             ast.c_for("n", self.cdim,
                                       ast.Assign(ast.Symbol("ret", ("n", )),
                                                  ops[op](ast.Symbol("self", ("n", )),

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -53,6 +53,7 @@ class Configuration(object):
     :param lazy_max_trace_length: How many :func:`par_loop`\s
         should be queued lazily before forcing evaluation?  Pass
         `0` for an unbounded length.
+    :param loop_fusion: Should loop fusion be on or off?
     :param dump_gencode: Should PyOP2 write the generated code
         somewhere for inspection?
     :param dump_gencode_path: Where should the generated code be
@@ -74,6 +75,7 @@ class Configuration(object):
         "log_level": ("PYOP2_LOG_LEVEL", (str, int), "WARNING"),
         "lazy_evaluation": ("PYOP2_LAZY", bool, True),
         "lazy_max_trace_length": ("PYOP2_MAX_TRACE_LENGTH", int, 0),
+        "loop_fusion": ("PYOP2_LOOP_FUSION", bool, False),
         "dump_gencode": ("PYOP2_DUMP_GENCODE", bool, False),
         "cache_dir": ("PYOP2_CACHE_DIR", str,
                       os.path.join(gettempdir(),

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -381,7 +381,9 @@ class ParLoop(openmp.ParLoop):
     def __init__(self, kernel, it_space, *args, **kwargs):
         read_args = [a.data for a in args if a.access in [READ, RW]]
         written_args = [a.data for a in args if a.access in [RW, WRITE, MIN, MAX, INC]]
-        LazyComputation.__init__(self, set(read_args) | Const._defs, set(written_args))
+        inc_args = [a.data for a in args if a.access in [INC]]
+        LazyComputation.__init__(self, set(read_args) | Const._defs,
+                                 set(written_args), set(inc_args))
 
         self._kernel = kernel
         self._actual_args = args

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -187,6 +187,7 @@ class JITModule(openmp.JITModule):
 
     _cppargs = []
     _libraries = []
+    _extension = 'cpp'
 
     _wrapper = """
 extern "C" void %(wrapper_name)s(%(executor_arg)s,

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -38,45 +38,29 @@ from collections import OrderedDict
 from copy import deepcopy as dcopy
 import os
 
-from base import LazyComputation, Const, _trace, \
-    READ, WRITE, RW, INC, MIN, MAX
+from base import _trace, READ, WRITE, RW, IterationIndex
 import host
 import compilation
-from host import Kernel  # noqa: for inheritance
-from openmp import _detect_openmp_flags
+from caching import Cached
+from host import Kernel
 from profiling import lineprof, timed_region, profile
 from logger import warning
 from mpi import collective
+from op2 import par_loop
 from utils import flatten
-from op2 import par_loop, Kernel
 
 import coffee
 from coffee import base as coffee_ast
 from coffee.utils import visit as coffee_ast_visit, \
-    ast_replace as coffee_ast_replace
+    ast_update_id as coffee_ast_update_id
 
 import slope_python as slope
 
 # hard coded value to max openmp threads
 _max_threads = 32
-# cache of inspectors for all of the loop chains encountered in the execution
-_inspectors = {}
 # track the loop chain in a time stepping loop which is being unrolled
 # this is a 2-tuple: (loop_chain_name, loops)
 _active_loop_chain = ()
-
-
-class LoopChain(object):
-    """Define a loop chain through a set of information:
-
-        * loops: a list of loops crossed
-        * time_unroll: an integer indicating how many times the loop chain was
-                       unrolled in the time stepping loop embedding it
-    """
-
-    def __init__(self, loops, time_unroll):
-        self.loops = loops
-        self.time_unroll = time_unroll
 
 
 class Arg(host.Arg):
@@ -94,40 +78,240 @@ class Arg(host.Arg):
              'vec_name': self.c_vec_name(),
              'arity': self.map.arity * cdim * (2 if is_facet else 1)}
 
+# Parallel loop API
 
-class Inspector(object):
-    """Represent the inspector for the fused sequence of :class:`ParLoop`.
+
+class ParLoop(host.ParLoop):
+
+    def __init__(self, kernel, iterset, inspection, *args, **kwargs):
+        super(ParLoop, self).__init__(kernel, iterset[0], *args, **kwargs)
+        self._inspection = inspection
+
+    @collective
+    @profile
+    def compute(self):
+        """Execute the kernel over all members of the iteration space."""
+        with timed_region("ParLoopChain `%s`: compute" % self.name):
+            self._compute()
+
+    @collective
+    @lineprof
+    def _compute(self):
+        with timed_region("ParLoopChain `%s`: executor" % self.name):
+            pass
+
+    def build_itspace(self, iterset):
+        return [super(ParLoop, self).build_itspace(iterset)]
+
+
+class Schedule(object):
+    """Represent an execution scheme for a sequence of :class:`ParLoop` objects."""
+
+    def __init__(self, kernels):
+        self._kernels = kernels
+
+    def to_par_loop(self, loop_chain):
+        """The argument ``loop_chain`` is a list of :class:`ParLoop` objects,
+        which is expected to be mapped onto an optimized scheduling.
+
+        In the simplest case, this Schedule's kernels exactly match the :class:`Kernel`
+        objects in ``loop_chain``; in this case, the scheduling is given by the
+        subsequent execution of the ``par_loops``; that is, resorting to the default
+        PyOP2 execution model.
+
+        In other scenarions, this Schedule's kernels could represent the fused
+        version, or the tiled version, of the ``par_loops``' kernels in the provided
+        ``loop_chain`` argument. In such a case, a sequence of :class:`ParLoop`
+        objects using the fused/tiled kernels is returned.
+        """
+        raise NotImplementedError("Subclass must implement instantiation of ParLoops")
+
+
+class PlainSchedule(Schedule):
+
+    def __init__(self):
+        super(PlainSchedule, self).__init__([])
+
+    def to_par_loop(self, loop_chain):
+        return loop_chain
+
+
+class FusionSchedule(Schedule):
+    """Schedule for a sequence of soft/hard fused :class:`ParLoop` objects."""
+
+    def __init__(self, kernels, ranges):
+        super(FusionSchedule, self).__init__(kernels)
+        self._ranges = ranges
+
+    def to_par_loop(self, loop_chain):
+        offset = 0
+        fused_par_loops = []
+        for kernel, range in zip(self._kernels, self._ranges):
+            iterset = loop_chain[offset].it_space.iterset
+            args = flatten([loop.args for loop in loop_chain[offset:range]])
+            fused_par_loops.append(par_loop(kernel, iterset, *args))
+            offset = range
+        return fused_par_loops
+
+
+class TilingSchedule(Schedule):
+    """Schedule for a sequence of tiled :class:`ParLoop` objects."""
+
+    def __init__(self, kernels, inspection):
+        super(TilingSchedule, self).__init__(kernels)
+        self._inspection = inspection
+
+    def _filter_args(self, loop_chain):
+        """Uniquify arguments and access modes"""
+        args = OrderedDict()
+        for loop in loop_chain:
+            # 1) Analyze the Args in each loop composing the chain and produce a
+            # new sequence of Args for the tiled ParLoop. For example, consider the
+            # Arg X and X.DAT be written to in ParLoop_0 (access mode WRITE) and
+            # read from in ParLoop_1 (access mode READ); this means that in the
+            # tiled ParLoop, X will have access mode RW
+            for a in loop.args:
+                args[a.data] = args.get(a.data, a)
+                if a.access != args[a.data].access:
+                    if READ in [a.access, args[a.data].access]:
+                        # If a READ and some sort of write (MIN, MAX, RW, WRITE,
+                        # INC), then the access mode becomes RW
+                        args[a.data] = a.data(RW, a.map, a._flatten)
+                    elif WRITE in [a.access, args[a.data].access]:
+                        # Can't be a READ, so just stick to WRITE regardless of what
+                        # the other access mode is
+                        args[a.data] = a.data(WRITE, a.map, a._flatten)
+                    else:
+                        # Neither READ nor WRITE, so access modes are some
+                        # combinations of RW, INC, MIN, MAX. For simplicity,
+                        # just make it RW.
+                        args[a.data] = a.data(RW, a.map, a._flatten)
+        return args.values()
+
+    def _filter_itersets(self, loop_chain):
+        return [loop.it_space.iterset for loop in loop_chain]
+
+    def to_par_loop(self, loop_chain):
+        args = self._filter_args(loop_chain)
+        iterset = self._filter_itersets(loop_chain)
+        return [ParLoop(self._kernels, iterset, self._inspection, *args)]
+
+
+class Inspector(Cached):
+    """An inspector is used to fuse or tile a sequence of :class:`ParLoop` objects.
 
     The inspector is implemented by the SLOPE library, which the user makes
     visible by setting the environment variable ``SLOPE_DIR`` to the value of
     the root SLOPE directory."""
 
+    _cache = {}
+
     _globaldata = {'coords': None}
+    _modes = ['soft', 'hard', 'tile']
+
+    @classmethod
+    def _cache_key(cls, name, loop_chain, tile_size):
+        key = (name, tile_size)
+        for loop in loop_chain:
+            for arg in loop.args:
+                if arg._is_global:
+                    key += (arg.data.dim, arg.data.dtype, arg.access)
+                elif arg._is_dat:
+                    if isinstance(arg.idx, IterationIndex):
+                        idx = (arg.idx.__class__, arg.idx.index)
+                    else:
+                        idx = arg.idx
+                    map_arity = arg.map.arity if arg.map else None
+                    key += (arg.data.dim, arg.data.dtype, map_arity, idx, arg.access)
+                elif arg._is_mat:
+                    idxs = (arg.idx[0].__class__, arg.idx[0].index,
+                            arg.idx[1].index)
+                    map_arities = (arg.map[0].arity, arg.map[1].arity)
+                    key += (arg.data.dims, arg.data.dtype, idxs, map_arities, arg.access)
+        return key
 
     def __init__(self, name, loop_chain, tile_size):
+        if self._initialized:
+            return
+        if not hasattr(self, '_inspected'):
+            # Initialization can occur more than once, but only the first time
+            # this attribute should be set
+            self._inspected = 0
         self._name = name
         self._tile_size = tile_size
         self._loop_chain = loop_chain
 
-        # Filter args, dats and maps for later retrieval
-        args_per_loop = [l.args for l in loop_chain]
-        self._dats = dict([(a.data.name, a.data) for a in flatten(args_per_loop)])
-        self._maps = dict([(a.map.name, a.map) for a in flatten(args_per_loop) if a.map])
+    def inspect(self, mode):
+        """Inspect this Inspector's loop chain and produce a Schedule object.
 
-        # The following flag is set to true once the inspector gets executed
-        self._initialized = False
-
-    def inspect(self):
-        if self._initialized:
-            return
+        :param mode: can take any of the values in ``Inspector._modes``, namely
+                     ``soft``, ``hard``, and ``tile``. If ``soft`` is specified,
+                     only soft fusion takes place; that is, only consecutive loops
+                     over the same iteration set that do not present RAW or WAR
+                     dependencies through indirections are fused. If ``hard`` is
+                     specified, then first ``soft`` is applied, followed by fusion
+                     of loops over different iteration sets, provided that RAW or
+                     WAR dependencies are not present. If ``tile`` is specified,
+                     than tiling through the SLOPE library takes place just after
+                     ``soft`` and ``hard`` fusion.
+        """
+        self._inspected += 1
+        if self._heuristic_skip_inspection():
+            # Heuristically skip this inspection if there is a suspicion the
+            # overhead is going to be too much; for example, when the loop
+            # chain could potentially be execution only once or a few time.
+            # Blow away everything we don't need any more
+            del self._name
+            del self._loop_chain
+            del self._tile_size
+            return PlainSchedule()
+        elif hasattr(self, '_schedule'):
+            # An inspection plan is in cache.
+            # It should not be possible to pull a jit module out of the cache
+            # /with/ the loop chain
+            if hasattr(self, '_loop_chain'):
+                raise RuntimeError("Inspector is holding onto loop_chain, memory leaks!")
+            # The fusion mode was recorded, and must match the one provided for
+            # this inspection
+            if self.mode != mode:
+                raise RuntimeError("Cached Inspector's mode doesn't match")
+            return self._schedule
+        elif not hasattr(self, '_loop_chain'):
+            # The inspection should be executed /now/. We weren't in the cache,
+            # so we /must/ have a loop chain
+            raise RuntimeError("Inspector must have a loop chain associated with it")
+        # Finally, we check the legality of `mode`
+        if mode not in Inspector._modes:
+            raise TypeError("Inspection accepts only %s fusion modes",
+                            str(Inspector._modes))
+        self._mode = mode
+        mode = Inspector._modes.index(mode)
 
         with timed_region("ParLoopChain `%s`: inspector" % self._name):
-            self._hard_fuse()
-            self._tile()
+            self._soft_fuse()
+            if mode > 0:
+                self._tile()
 
+        # A schedule has been computed by any of /_soft_fuse/, /_hard_fuse/ or
+        # or /_tile/; therefore, consider this Inspector initialized, and
+        # retrievable from cache in subsequent calls to inspect().
         self._initialized = True
 
-    def _hard_fuse(self):
+        # Blow away everything we don't need any more
+        del self._name
+        del self._loop_chain
+        del self._tile_size
+        return self._schedule
+
+    def _heuristic_skip_inspection(self):
+        """Decide heuristically whether to run an inspection or not."""
+        # At the moment, a simple heuristic is used: if the inspection is
+        # requested more than once, then it is performed
+        if self._inspected < 2:
+            return True
+        return False
+
+    def _soft_fuse(self):
         """Fuse consecutive loops over the same iteration set by concatenating
         kernel bodies and creating new :class:`ParLoop` objects representing
         the fused sequence.
@@ -167,10 +351,8 @@ class Inspector(object):
             ast_b_decls = ast_b_info['decls']
             ast_b_symbols = ast_b_info['symbols']
             for str_sym, decl in ast_b_decls.items():
-                new_symbol_id = "%s_%s" % (str_sym, str(unique_id))
                 for symbol in ast_b_symbols.keys():
-                    if symbol.symbol == str_sym:
-                        symbol.symbol = new_symbol_id
+                    coffee_ast_update_id(symbol, str_sym, unique_id)
             # 2-C) Concatenate kernels' bodies
             marker_ast_node = coffee_ast.FlatBlock("\n\n// Begin of fused kernel\n\n")
             fused_ast.children[0].children.extend([marker_ast_node] + ast_b.children)
@@ -179,15 +361,19 @@ class Inspector(object):
             kernel = Kernel(fused_ast, name, opts, include_dirs, headers, user_code)
             return par_loop(kernel, loop_a.it_space.iterset, *args)
 
-        loop_chain, fusing_loop  = [], []
+        # In the process of soft fusion, temporary "fake" ParLoops are constructed
+        # to simplify tracking of data dependencies.
+        # In the following, the word "range" indicates an offset in the original
+        # loop chain to represent of slice of original ParLoops that have been fused
+        fused_loops_ranges, fusing_loop_range = [], []
         base_loop = self._loop_chain[0]
-        for i, loop in enumerate(self._loop_chain[1:]):
+        for i, loop in enumerate(self._loop_chain[1:], 1):
             if base_loop.it_space != loop.it_space or \
                     (base_loop.is_indirect and loop.is_indirect):
                 # Fusion not legal
-                loop_chain.append(base_loop)
+                fused_loops_ranges.append((base_loop, i))
                 base_loop = loop
-                fusing_loop = []
+                fusing_loop_range = []
                 continue
             elif base_loop.is_direct and loop.is_direct:
                 base_loop = do_fuse(base_loop, loop, i)
@@ -195,9 +381,14 @@ class Inspector(object):
                 base_loop = do_fuse(loop, base_loop, i)
             elif base_loop.is_indirect and loop.is_direct:
                 base_loop = do_fuse(base_loop, loop, i)
-            fusing_loop = [base_loop]
-        loop_chain.extend(fusing_loop)
-        self._loop_chain = loop_chain
+            fusing_loop_range = [(base_loop, i+1)]
+        fused_loops_ranges.extend(fusing_loop_range)
+
+        fused_loop_chain, ranges = zip(*fused_loops_ranges)
+        fused_kernels = [loop.kernel for loop in fused_loop_chain]
+
+        self._loop_chain = fused_loop_chain
+        self._schedule = FusionSchedule(fused_kernels, ranges)
 
     def _tile(self):
         """Tile consecutive loops over different iteration sets characterized
@@ -243,136 +434,41 @@ class Inspector(object):
         # Return type of the inspector
         rettype = slope.Executor._ctype
 
-        # Compile and line options
+        # Compiler and linker options
         slope_dir = os.environ['SLOPE_DIR']
         compiler = coffee.plan.compiler.get('name')
         cppargs = slope.get_compile_opts(compiler, coords)
         cppargs += ['-I%s/sparsetiling/include' % slope_dir]
         ldargs = ['-L%s/lib' % slope_dir, '-l%s' % slope.get_lib_name()]
 
+        # Compile and run inspector
         fun = compilation.load(src, "cpp", "inspector", cppargs, ldargs,
                                argtypes, rettype, compiler)
-        c_executor = fun(*argvalues, argtypes=argtypes, restype=None)
+        inspection = fun(*argvalues)
 
+        executor = slope.Executor(inspector)
 
-# Parallel loop API
+        # Generate executor C code
+        src = executor.generate_code()
 
-
-class JITModule(host.JITModule):
-    """Represent the executor code for the fused sequence of :class:`ParLoop`"""
-
-    ompflag, omplib = _detect_openmp_flags()
-    _cppargs = [os.environ.get('OMP_CXX_FLAGS') or ompflag]
-    _libraries = [ompflag] + [os.environ.get('OMP_LIBS') or omplib]
-    _system_headers = ['#include <omp.h>']
-
-    _wrapper = """
-"""
-
-    def generate_code(self):
-
-        # Bits of the code to generate are the same as that for sequential
-        code_dict = super(JITModule, self).generate_code()
-
-        return code_dict
-
-
-class ParLoop(host.ParLoop):
-
-    def __init__(self, name, loop_chain, tile_size):
-        self._name = name
-        self._loop_chain = loop_chain
-
-        # Extrapolate arguments and iteration spaces
-        args, it_spaces = OrderedDict(), []
-        for loop in loop_chain:
-            # 1) Analyze the Args in each loop composing the chain and produce a
-            # new sequence of Args for the fused ParLoop. For example, consider the
-            # Arg X and X.DAT be written to in ParLoop_0 (access mode WRITE) and
-            # read from in ParLoop_1 (access mode READ); this means that in the
-            # fused ParLoop, X will have access mode RW
-            for a in loop.args:
-                args[a.data] = args.get(a.data, a)
-                if a.access != args[a.data].access:
-                    if READ in [a.access, args[a.data].access]:
-                        # If a READ and some sort of write (MIN, MAX, RW, WRITE, INC),
-                        # then the access mode becomes RW
-                        args[a.data] = a.data(RW, a.map, a._flatten)
-                    elif WRITE in [a.access, args[a.data].access]:
-                        # Can't be a READ, so just stick to WRITE regardless of what
-                        # the other access mode is
-                        args[a.data] = a.data(WRITE, a.map, a._flatten)
-                    else:
-                        # Neither READ nor WRITE, so access modes are some combinations
-                        # of RW, INC, MIN, MAX. For simplicity, just make it RW
-                        args[a.data] = a.data(RW, a.map, a._flatten)
-            # 2) The iteration space of the fused loop is the union of the iteration
-            # spaces of the individual loops composing the chain
-            it_spaces.append(loop.it_space)
-
-        self._actual_args = args.values()
-        self._it_spaces = it_spaces
-
-        # Set an inspector for this fused parloop
-        global _inspectors
-        _inspectors[name] = _inspectors.get(name, Inspector(name, loop_chain, tile_size))
-        self._inspector = _inspectors[name]
-
-        # The fused parloop can still be lazily evaluated
-        LazyComputation.__init__(self,
-                                 set([a.data for a in self._actual_args
-                                      if a.access in [READ, RW]]) | Const._defs,
-                                 set([a.data for a in self._actual_args
-                                      if a.access in [RW, WRITE, MIN, MAX, INC]]))
-
-    @collective
-    @profile
-    def compute(self):
-        """Execute the kernel over all members of the iteration space."""
-        with timed_region("ParLoopChain `%s`: compute" % self.name):
-            self._compute()
-
-    @collective
-    @lineprof
-    def _compute(self):
-        self._get_plan()
-
-        with timed_region("ParLoopChain `%s`: executor" % self.name):
-            pass
-
-    def _get_plan(self):
-        """Retrieve an execution plan by generating, jit-compiling and running
-        an inspection scheme implemented through calls to the SLOPE library.
-
-        Note that inspection will be executed only once for identical loop chains.
-        """
-        self._inspector.inspect()
+        # Create the Kernel object, which contains the executor code
+        kernel = Kernel(src, "executor")
+        self._schedule = TilingSchedule(kernel, inspection)
 
     @property
-    def it_space(self):
-        return self._it_spaces
-
-    @property
-    def inspector(self):
-        return self._inspector
-
-    @property
-    def loop_chain(self):
-        return self._loop_chain
-
-    @property
-    def name(self):
-        return self._name
+    def mode(self):
+        return self._mode
 
 
-def fuse_loops(name, loop_chain, tile_size):
-    """Given a list of :class:`openmp.ParLoop`, return a :class:`fused_openmp.ParLoop`
-    object representing the fusion of the loop chain. The original list is instead
-    returned if ``loop_chain`` presents one of the following non currently supported
-    features:
+def reschedule_loops(name, loop_chain, tile_size, mode='tile'):
+    """Given a list of :class:`ParLoop` in ``loop_chain``, return a list of new
+    :class:`ParLoop` objects implementing an optimized scheduling of the loop chain.
 
-        * a global reduction;
-        * iteration over extruded sets
+    .. note:: The unmodified loop chain is instead returned if any of these
+    conditions verify:
+
+        * a global reduction is present;
+        * at least one loop iterates over an extruded set
     """
 
     # Loop fusion is performed through the SLOPE library, which must be accessible
@@ -389,79 +485,61 @@ def fuse_loops(name, loop_chain, tile_size):
             any([l.is_layered for l in loop_chain]):
         return loop_chain
 
-    return ParLoop(name, loop_chain, tile_size)
+    # Get an inspector for fusing this loop_chain, possibly retrieving it from
+    # the cache, and obtain the fused ParLoops through the schedule it produces
+    inspector = Inspector(name, loop_chain, tile_size)
+    schedule = inspector.inspect(mode)
+    return schedule.to_par_loop(loop_chain)
 
 
 @contextmanager
-def loop_chain(name, time_unroll=0, tile_size=0, coords=None):
-    """Analyze the trace of lazily evaluated loops ::
+def loop_chain(name, time_unroll=1, tile_size=0, coords=None):
+    """Analyze the sub-trace of loops lazily evaluated in this contextmanager ::
 
         [loop_0, loop_1, ..., loop_n-1]
 
-    and produce a new trace ::
+    and produce a new sub-trace (``m <= n``) ::
 
-        [fused_loopchain_0, fused_loopchain_1, ..., fused_loopchain_n-1, peel_loop_i]
+        [fused_loops_0, fused_loops_1, ..., fused_loops_m-1, peel_loops]
 
-    where sequences of loops of length ``_max_loop_chain_length`` (which is a global
-    variable) are replaced by openmp_fused.ParLoop instances, plus a trailing
-    sequence of loops in case ``n`` is greater than and does not divide equally
-    ``_max_loop_chain_length``.
+    which is eventually inserted in the global trace of :class:`ParLoop` objects.
+
+    That is, sub-sequences of :class:`ParLoop` objects are potentially replaced by
+    new :class:`ParLoop` objects representing the fusion or the tiling of the
+    original trace slice.
 
     :param name: identifier of the loop chain
-    :param time_unroll: if in a time stepping loop, the length of the loop chain
-                        will be ``num_loops * time_unroll``, where ``num_loops``
-                        is the number of loops in the time stepping loop. By
-                        setting this parameter to a value greater than 0, the runtime
-                        system is informed that the loop chain should be extracted
-                        from a time stepping loop, which can results in better
-                        fusion (by 1- descarding the first loop chain iteration,
-                        in which some time-independent loops may be evaluated
-                        and stored in temporaries for later retrieval, and 2-
-                        allowing tiling through inspection/execution).
-                        If the value of this parameter is greater than zero, but
-                        the loop chain is not actually in a time stepping loop,
-                        the behaviour is undefined.
-    :param tile_size: suggest a tile size in case loop fusion can only be achieved
-                      trough tiling within a time stepping loop.
+    :param time_unroll: in a time stepping loop, the length of the loop chain
+                        is given by ``num_loops * time_unroll``, where ``num_loops``
+                        is the number of loops per time loop iteration. Therefore,
+                        setting this value to a number greater than 1 enables
+                        fusing/tiling longer loop chains (optional, defaults to 1).
+    :param tile_size: suggest a tile size in case loop tiling is used (optional).
     :param coords: :class:`pyop2.Dat` representing coordinates. This should be
                    passed only if in debugging mode, because it affects the runtime
                    of the computation by generating VTK files illustrating the
-                   result of mesh coloring resulting from fusing loops through
-                   tiling. If SLOPE is not available, then this parameter has no
-                   effect and is simply ignored.
+                   result of mesh coloring resulting from tiling.
     """
 
-    global _active_loop_chain, _inspectors_metadata
-    trace, new_trace = _trace._trace, []
+    trace = _trace._trace
+    stamp = trace[-1:]
 
-    # Mark the last loop out of the loop chain
-    pre_loop_chain = trace[-1:]
     yield
-    start_point = trace.index(pre_loop_chain[0])+1 if pre_loop_chain else 0
-    loop_chain = trace[start_point:]
+
+    if time_unroll < 1:
+        return
+
+    start_point = trace.index(stamp[0])+1 if stamp else 0
+    extracted_loop_chain = trace[start_point:]
 
     # Add any additional information that could be useful for inspection
     Inspector._globaldata['coords'] = coords
 
-    if time_unroll == 0:
-        # If *not* in a time stepping loop, just replace the loops in the trace
-        # with a fused version
-        trace[start_point:] = [fuse_loops(name, loop_chain, tile_size)]
-        _active_loop_chain = ()
-        return
-    if not _active_loop_chain or _active_loop_chain[0] != name:
-        # In a time stepping loop; open a new context and discard first iteration
-        # by returning immediately, since the first iteration may be characterized
-        # by the computation of time-independent loops (i.e., loops that are
-        # executed only once and accessed in read-only mode successively)
-        _active_loop_chain = (name, [])
-        return
+    # Unroll the loop chain ``time_unroll`` times before fusion/tiling
+    total_loop_chain = loop_chain.unrolled_loop_chain + extracted_loop_chain
+    if len(total_loop_chain) / len(extracted_loop_chain) == time_unroll:
+        trace[start_point:] = reschedule_loops(name, total_loop_chain, tile_size)
+        loop_chain.unrolled_loop_chain = []
     else:
-        # In a time stepping loop; unroll the loop chain ``time_unroll`` times
-        # before replacing with the fused version
-        unrolled_loop_chain = _active_loop_chain[1]
-        current_loop_chain = unrolled_loop_chain + loop_chain
-        if len(current_loop_chain) / len(loop_chain) == time_unroll:
-            trace[start_point:] = [fuse_loops(name, current_loop_chain, tile_size)]
-        else:
-            unrolled_loop_chain.extend(loop_chain)
+        unrolled_loop_chain.extend(total_loop_chain)
+loop_chain.unrolled_loop_chain = []

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -46,9 +46,10 @@ import compilation
 import host
 from caching import Cached
 from profiling import lineprof, timed_region, profile
-from logger import warning
+from logger import warning, info
 from mpi import collective
 from op2 import par_loop
+from configuration import configuration
 from utils import flatten, strip, as_tuple
 
 import coffee
@@ -719,7 +720,15 @@ class Inspector(Cached):
         """Tile consecutive loops over different iteration sets characterized
         by RAW and WAR dependencies. This requires interfacing with the SLOPE
         library."""
-        inspector = slope.Inspector('OMP')
+        try:
+            backend_map = {'sequential': 'SEQUENTIAL', 'openmp': 'OMP'}
+            slope_backend = backend_map[configuration['backend']]
+            slope.set_exec_mode(slope_backend)
+            info("SLOPE backend set to %s" % slope_backend)
+        except KeyError:
+            warning("Unable to set backend %s for SLOPE" % configuration['backend'])
+
+        inspector = slope.Inspector()
 
         # Build arguments types and values
         arguments = []

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -789,7 +789,7 @@ class Inspector(Cached):
 
 # Interface for triggering loop fusion
 
-def reschedule_loops(name, loop_chain, tile_size, mode='tile'):
+def reschedule_loops(name, loop_chain, tile_size):
     """Given a list of :class:`ParLoop` in ``loop_chain``, return a list of new
     :class:`ParLoop` objects implementing an optimized scheduling of the loop chain.
 
@@ -812,6 +812,9 @@ def reschedule_loops(name, loop_chain, tile_size, mode='tile'):
     if any([l._reduced_globals for l in loop_chain]) or \
             any([l.is_layered for l in loop_chain]):
         return loop_chain
+
+    # Set the fusion mode based on user-provided parameters
+    mode = 'soft' if tile_size == 0 else 'tile'
 
     # Get an inspector for fusing this loop_chain, possibly retrieving it from
     # the cache, and obtain the fused ParLoops through the schedule it produces
@@ -843,6 +846,7 @@ def loop_chain(name, time_unroll=1, tile_size=0):
                         setting this value to a number greater than 1 enables
                         fusing/tiling longer loop chains (optional, defaults to 1).
     :param tile_size: suggest a tile size in case loop tiling is used (optional).
+                      If ``0`` is passed in, only soft fusion is performed.
     """
     trace = _trace._trace
     stamp = trace[-1:]

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -858,8 +858,9 @@ def loop_chain(name, time_unroll=1, tile_size=0):
     # Unroll the loop chain ``time_unroll`` times before fusion/tiling
     total_loop_chain = loop_chain.unrolled_loop_chain + extracted_loop_chain
     if len(total_loop_chain) / len(extracted_loop_chain) == time_unroll:
+        start_point = trace.index(total_loop_chain[0])
         trace[start_point:] = reschedule_loops(name, total_loop_chain, tile_size)
         loop_chain.unrolled_loop_chain = []
     else:
-        loop_chain.unrolled_loop_chain.extend(total_loop_chain)
+        loop_chain.unrolled_loop_chain.extend(extracted_loop_chain)
 loop_chain.unrolled_loop_chain = []

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -724,9 +724,24 @@ class Inspector(Cached):
 
     def _hard_fuse(self):
         """Fuse consecutive loops over different iteration sets that do not
-        present RAW or WAR dependencies. This requires interfacing with the
-        SLOPE library."""
-        hf = slope.HardFusion(self._loop_chain)()
+        present RAW, WAR or WAW dependencies. For examples, two loops like: ::
+
+            par_loop(kernel_1, it_space_1,
+                     dat_1_1(INC, ...),
+                     dat_1_2(READ, ...),
+                     ...)
+
+            par_loop(kernel_2, it_space_2,
+                     dat_2_1(INC, ...),
+                     dat_2_2(READ, ...),
+                     ...)
+
+        where ``dat_1_1 == dat_2_1`` and, possibly (but not necessarily),
+        ``it_space_1 != it_space_2``, can be hardly fused. Note, in fact, that
+        the presence of ``INC`` does not imply a real WAR dependency, because
+        increments are associative.
+        This requires interfacing with the SLOPE library."""
+        pass
 
     def _tile(self):
         """Tile consecutive loops over different iteration sets characterized

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -38,17 +38,17 @@ from collections import OrderedDict
 from copy import deepcopy as dcopy
 import os
 
-from base import _trace, IterationIndex, LazyComputation, Const, IterationSpace, \
-    READ, WRITE, RW, MIN, MAX, INC
-import host
+from base import _trace
+from base import *
+import openmp
 import compilation
+import host
 from caching import Cached
-from host import Kernel
 from profiling import lineprof, timed_region, profile
 from logger import warning
 from mpi import collective
 from op2 import par_loop
-from utils import flatten
+from utils import flatten, strip, as_tuple
 
 import coffee
 from coffee import base as coffee_ast
@@ -61,35 +61,310 @@ import slope_python as slope
 _max_threads = 32
 
 
-class Arg(host.Arg):
+class Arg(openmp.Arg):
 
-    def c_kernel_arg_name(self, i, j, idx=None):
-        return "p_%s[%s]" % (self.c_arg_name(i, j), idx or 'tid')
+    @staticmethod
+    def specialize(args, gtl_map, loop_id):
+        """Given ``args`` instances of some :class:`fusion.Arg` superclass,
+        create and return specialized :class:`fusion.Arg` objects.
 
-    def c_local_tensor_name(self, i, j):
-        return self.c_kernel_arg_name(i, j, _max_threads)
+        :param args: either a single :class:`host.Arg` object or an iterator
+                     (accepted: list, tuple) of :class:`host.Arg` objects.
+        :gtl_map: a dict associating global maps' names to local maps' c_names.
+        :param loop_id: indicates the position of the args` loop in the loop
+                        chain
+        """
 
-    def c_vec_dec(self, is_facet=False):
-        cdim = self.data.dataset.cdim if self._flatten else 1
-        return ";\n%(type)s *%(vec_name)s[%(arity)s]" % \
-            {'type': self.ctype,
-             'vec_name': self.c_vec_name(),
-             'arity': self.map.arity * cdim * (2 if is_facet else 1)}
+        def convert(arg, gtl_map, loop_id):
+            # Retrive local maps
+            maps = as_tuple(arg.map, Map)
+            c_local_maps = [None]*len(maps)
+            for i, map in enumerate(maps):
+                c_local_maps[i] = [None]*len(map)
+                for j, m in enumerate(map):
+                    c_local_maps[i][j] = gtl_map["%s%d_%d" % (m.name, i, j)]
+            # Instantiate and initialize new, specialized Arg
+            _arg = Arg(arg.data, arg.map, arg.idx, arg.access, arg._flatten)
+            _arg._loop_position = loop_id
+            _arg._position = arg._position
+            _arg._indirect_position = arg._indirect_position
+            _arg._c_local_maps = c_local_maps
+            return _arg
+
+        if isinstance(args, (list, tuple)):
+            return [convert(arg, gtl_map, loop_id) for arg in args]
+        return convert(args, gtl_map, loop_id)
+
+    def c_arg_bindto(self, arg):
+        """Assign c_pointer of this Arg to ``arg``."""
+        if self.ctype != arg.ctype:
+            raise RuntimeError("Cannot bind arguments having mismatching types")
+        return "%s* %s = %s" % (self.ctype, self.c_arg_name(), arg.c_arg_name())
+
+    def c_map_name(self, i, j):
+        return self._c_local_maps[i][j]
+
+    @property
+    def name(self):
+        """The generated argument name."""
+        return "arg_exec_loop%d_%d" % (self._loop_position, self._position)
+
+
+class Kernel(openmp.Kernel, tuple):
+
+    @classmethod
+    def _cache_key(cls, kernels, fuse=True):
+        return "".join([super(Kernel, cls)._cache_key(k.code, k.name, k._opts,
+                                                      k._include_dirs, k._headers,
+                                                      k._user_code) for k in kernels])
+
+    def _ast_to_c(self, asts, opts):
+        """Fuse Abstract Syntax Trees of a collection of kernels and transform
+        them into a string of C code."""
+        asts = as_tuple(asts, (coffee_ast.FunDecl, coffee_ast.Root))
+
+        if len(asts) == 1 or not opts['fuse']:
+            self._ast = coffee_ast.Root(asts)
+            return self._ast.gencode()
+
+        # Fuse the actual kernels' bodies
+        fused_ast = dcopy(asts[0])
+        if not isinstance(fused_ast, coffee_ast.FunDecl):
+            # Need to get the Function declaration, so inspect the children
+            fused_ast = [n for n in fused_ast.children
+                         if isinstance(n, coffee_ast.FunDecl)][0]
+        for unique_id, _ast in enumerate(asts[1:], 1):
+            ast = dcopy(_ast)
+            # 1) Extend function name
+            fused_ast.name = "%s_%s" % (fused_ast.name, ast.name)
+            # 2) Concatenate the arguments in the signature
+            fused_ast.args.extend(ast.args)
+            # 3) Uniquify symbols identifiers
+            ast_info = coffee_ast_visit(ast, None)
+            ast_decls = ast_info['decls']
+            ast_symbols = ast_info['symbols']
+            for str_sym, decl in ast_decls.items():
+                for symbol in ast_symbols.keys():
+                    coffee_ast_update_id(symbol, str_sym, unique_id)
+            # 4) Concatenate bodies
+            marker_ast_node = coffee_ast.FlatBlock("\n\n// Begin of fused kernel\n\n")
+            fused_ast.children[0].children.extend([marker_ast_node] + ast.children)
+
+        self._ast = fused_ast
+        return self._ast.gencode()
+
+    def __init__(self, kernels, fuse=True):
+        # Protect against re-initialization when retrieved from cache
+        if self._initialized:
+            return
+        kernels = as_tuple(kernels, (Kernel, host.Kernel))
+        self._kernels = kernels
+
+        Kernel._globalcount += 1
+        self._name = "_".join([kernel.name for kernel in kernels])
+        self._opts = dict(flatten([kernel._opts.items() for kernel in kernels]))
+        self._opts['fuse'] = fuse
+        self._applied_blas = any(kernel._applied_blas for kernel in kernels)
+        self._applied_ap = any(kernel._applied_ap for kernel in kernels)
+        self._include_dirs = list(set(flatten([kernel._include_dirs for kernel
+                                               in kernels])))
+        self._headers = list(set(flatten([kernel._headers for kernel in kernels])))
+        self._user_code = "\n".join([kernel._user_code for kernel in kernels])
+        self._code = self._ast_to_c([kernel._ast for kernel in kernels], self._opts)
+        self._initialized = True
+
+    def __iter__(self):
+        for kernel in self._kernels:
+            yield kernel
+
+    def __str__(self):
+        return "OP2 FusionKernel: %s" % self._name
 
 
 # Parallel loop API
 
-class ParLoop(host.ParLoop):
+class JITModule(openmp.JITModule):
 
-    def __init__(self, kernel, iterset, inspection, *args, **kwargs):
+    _cppargs = []
+    _libraries = []
+
+    _wrapper = """
+extern "C" void %(wrapper_name)s(%(executor_arg)s,
+                      %(ssinds_arg)s
+                      %(wrapper_args)s
+                      %(const_args)s);
+void %(wrapper_name)s(%(executor_arg)s,
+                      %(ssinds_arg)s
+                      %(wrapper_args)s
+                      %(const_args)s) {
+  %(user_code)s
+  %(wrapper_decs)s;
+  %(const_inits)s;
+
+  %(executor_code)s;
+}
+"""
+    _kernel_wrapper = """
+%(interm_globals_decl)s;
+%(interm_globals_init)s;
+%(vec_decs)s;
+%(args_binding)s;
+%(tile_init)s;
+for (int n = %(tile_start)s; n < %(tile_end)s; n++) {
+  int i = %(tile_iter)s[%(index_expr)s];
+  %(vec_inits)s;
+  %(buffer_decl)s;
+  %(buffer_gather)s
+  %(kernel_name)s(%(kernel_args)s);
+  %(layout_decl)s;
+  %(layout_loop)s
+      %(layout_assign)s;
+  %(layout_loop_close)s
+  %(itset_loop_body)s;
+}
+%(interm_globals_writeback)s;
+"""
+
+    @classmethod
+    def _cache_key(cls, kernel, it_space, *args, **kwargs):
+        key = (hash(kwargs['executor']),)
+        all_args = kwargs['all_args']
+        for kernel_i, it_space_i, args_i in zip(kernel, it_space, all_args):
+            key += super(JITModule, cls)._cache_key(kernel_i, it_space_i, *args_i)
+        return key
+
+    def __init__(self, kernel, it_space, *args, **kwargs):
+        if self._initialized:
+            return
+        self._all_args = kwargs.pop('all_args')
+        self._executor = kwargs.pop('executor')
+        super(JITModule, self).__init__(kernel, it_space, *args, **kwargs)
+
+    def compile(self, argtypes=None, restype=None):
+        if hasattr(self, '_fun'):
+            # It should not be possible to pull a jit module out of
+            # the cache /with/ arguments
+            if hasattr(self, '_args'):
+                raise RuntimeError("JITModule is holding onto args, memory leak!")
+            self._fun.argtypes = argtypes
+            self._fun.restype = restype
+            return self._fun
+        # If we weren't in the cache we /must/ have arguments
+        if not hasattr(self, '_args'):
+            raise RuntimeError("JITModule not in cache, but has no args associated")
+
+        # Prior to the instantiation and compilation of the JITModule, a fusion
+        # kernel object needs be created. This is because the superclass' method
+        # expects a single kernel, not a list as we have at this point.
+        self._kernel = Kernel(self._kernel, fuse=False)
+        # Set compiler and linker options
+        slope_dir = os.environ['SLOPE_DIR']
+        self._kernel._name = 'executor'
+        self._kernel._headers.extend(slope.Executor.meta['headers'])
+        self._kernel._include_dirs.extend(['%s/%s' % (slope_dir,
+                                                      slope.get_include_dir())])
+        self._libraries += ['-L%s/%s' % (slope_dir, slope.get_lib_dir()),
+                            '-l%s' % slope.get_lib_name()]
+        compiler = coffee.plan.compiler.get('name')
+        self._cppargs += slope.get_compile_opts(compiler)
+        fun = super(JITModule, self).compile(argtypes, restype)
+
+        if hasattr(self, '_all_args'):
+            # After the JITModule is compiled, can drop any reference to now
+            # useless fields, which would otherwise cause memory leaks
+            del self._all_args
+            del self._executor
+
+        return fun
+
+    def generate_code(self):
+        indent = lambda t, i: ('\n' + '  ' * i).join(t.split('\n'))
+        code_dict = {}
+
+        code_dict['wrapper_name'] = 'wrap_executor'
+        code_dict['executor_arg'] = "%s %s" % (slope.Executor.meta['ctype_exec'],
+                                               slope.Executor.meta['name_param_exec'])
+
+        # Construct the wrapper
+        _wrapper_args = ', '.join([arg.c_wrapper_arg() for arg in self._args])
+        _wrapper_decs = ';\n'.join([arg.c_wrapper_dec() for arg in self._args])
+        if len(Const._defs) > 0:
+            _const_args = ', '
+            _const_args += ', '.join([c_const_arg(c) for c in Const._definitions()])
+        else:
+            _const_args = ''
+        _const_inits = ';\n'.join([c_const_init(c) for c in Const._definitions()])
+
+        code_dict['wrapper_args'] = _wrapper_args
+        code_dict['const_args'] = _const_args
+        code_dict['wrapper_decs'] = indent(_wrapper_decs, 1)
+        code_dict['const_inits'] = indent(_const_inits, 1)
+
+        # Construct kernels invocation
+        _loop_chain_body, _user_code, _ssinds_arg = [], [], []
+        for i, loop in enumerate(zip(self._kernel, self._itspace, self._all_args)):
+            kernel, it_space, args = loop
+
+            # Obtain code_dicts of individual kernels, since these have pieces of
+            # code that can be straightforwardly reused for this code generation
+            loop_code_dict = host.JITModule(kernel, it_space, *args).generate_code()
+
+            # Need to bind executor arguments to this kernel's arguments
+            # Using a dict because need comparison on identity, not equality
+            args_dict = dict(zip([_a.data for _a in self._args], self._args))
+            binding = OrderedDict(zip(args, [args_dict[a.data] for a in args]))
+            if len(binding) != len(args):
+                raise RuntimeError("Tiling code gen failed due to args mismatching")
+            binding = ';\n'.join([a0.c_arg_bindto(a1) for a0, a1 in binding.items()])
+
+            loop_code_dict['args_binding'] = binding
+            loop_code_dict['tile_iter'] = self._executor.gtl_maps[i]['DIRECT']
+            loop_code_dict['tile_init'] = self._executor.c_loop_init[i]
+            loop_code_dict['tile_start'] = slope.Executor.meta['tile_start']
+            loop_code_dict['tile_end'] = slope.Executor.meta['tile_end']
+
+            _loop_chain_body.append(strip(JITModule._kernel_wrapper % loop_code_dict))
+            _user_code.append(kernel._user_code)
+            _ssinds_arg.append(loop_code_dict['ssinds_arg'])
+        _loop_chain_body = "\n\n".join(_loop_chain_body)
+        _user_code = "\n".join(_user_code)
+        _ssinds_arg = ", ".join([s for s in _ssinds_arg if s])
+
+        code_dict['user_code'] = indent(_user_code, 1)
+        code_dict['ssinds_arg'] = _ssinds_arg
+        executor_code = indent(self._executor.c_code(indent(_loop_chain_body, 2)), 1)
+        code_dict['executor_code'] = executor_code
+
+        return code_dict
+
+
+class ParLoop(openmp.ParLoop):
+
+    def __init__(self, kernel, it_space, *args, **kwargs):
         read_args = [a.data for a in args if a.access in [READ, RW]]
         written_args = [a.data for a in args if a.access in [RW, WRITE, MIN, MAX, INC]]
         LazyComputation.__init__(self, set(read_args) | Const._defs, set(written_args))
 
         self._kernel = kernel
         self._actual_args = args
-        self._inspection = inspection
-        self._it_space = self.build_itspace(iterset)
+        self._it_space = it_space
+
+        for i, arg in enumerate(self._actual_args):
+            arg.position = i
+            arg.indirect_position = i
+        for i, arg1 in enumerate(self._actual_args):
+            if arg1._is_dat and arg1._is_indirect:
+                for arg2 in self._actual_args[i:]:
+                    # We have to check for identity here (we really
+                    # want these to be the same thing, not just look
+                    # the same)
+                    if arg2.data is arg1.data and arg2.map is arg1.map:
+                        arg2.indirect_position = arg1.indirect_position
+
+        # These parameters are expected in a ParLoop based on tiling
+        self._inspection = kwargs['inspection']
+        self._all_args = kwargs['all_args']
+        self._executor = kwargs['executor']
 
     @collective
     @profile
@@ -102,12 +377,44 @@ class ParLoop(host.ParLoop):
     @lineprof
     def _compute(self):
         with timed_region("ParLoopChain: executor"):
-            pass
+            kwargs = {
+                'all_args': self._all_args,
+                'executor': self._executor,
+            }
+            fun = JITModule(self.kernel, self.it_space, *self.args, **kwargs)
 
-    def build_itspace(self, iterset):
-        # Note that the presence of any local iteration space is ignored
-        block_shape = None
-        return [IterationSpace(i, block_shape) for i in iterset]
+            # Build restype, argtypes and argvalues
+            self._restype = None
+            self._argtypes = [slope.Executor.meta['py_ctype_exec']]
+            self._jit_args = [self._inspection]
+            for it_space in self.it_space:
+                if isinstance(it_space._iterset, Subset):
+                    self._argtypes.append(it_space._iterset._argtype)
+                    self._jit_args.append(it_space._iterset._indices)
+            for arg in self.args:
+                if arg._is_mat:
+                    self._argtypes.append(arg.data._argtype)
+                    self._jit_args.append(arg.data.handle.handle)
+                else:
+                    for d in arg.data:
+                        # Cannot access a property of the Dat or we will force
+                        # evaluation of the trace
+                        self._argtypes.append(d._argtype)
+                        self._jit_args.append(d._data)
+
+                if arg._is_indirect or arg._is_mat:
+                    maps = as_tuple(arg.map, Map)
+                    for map in maps:
+                        for m in map:
+                            self._argtypes.append(m._argtype)
+                            self._jit_args.append(m.values_with_halo)
+
+            for c in Const._definitions():
+                self._argtypes.append(c._argtype)
+                self._jit_args.append(c.data)
+
+            # Compile and run the JITModule
+            fun = fun.compile(argtypes=self._argtypes, restype=self._restype)
 
 
 # Possible Schedules as produced by an Inspector
@@ -115,24 +422,23 @@ class ParLoop(host.ParLoop):
 class Schedule(object):
     """Represent an execution scheme for a sequence of :class:`ParLoop` objects."""
 
-    def __init__(self, kernels):
-        self._kernels = kernels
+    def __init__(self, kernel):
+        self._kernel = kernel
 
-    def to_par_loop(self, loop_chain):
+    def __call__(self, loop_chain):
         """The argument ``loop_chain`` is a list of :class:`ParLoop` objects,
         which is expected to be mapped onto an optimized scheduling.
 
         In the simplest case, this Schedule's kernels exactly match the :class:`Kernel`
-        objects in ``loop_chain``; in this case, the scheduling is given by the
-        subsequent execution of the ``par_loops``; that is, resorting to the default
-        PyOP2 execution model.
+        objects in ``loop_chain``; the default PyOP2 execution model should then be
+        used, and an unmodified ``loop_chain`` therefore be returned.
 
-        In other scenarions, this Schedule's kernels could represent the fused
-        version, or the tiled version, of the ``par_loops``' kernels in the provided
-        ``loop_chain`` argument. In such a case, a sequence of :class:`ParLoop`
-        objects using the fused/tiled kernels is returned.
+        In other scenarios, this Schedule's kernels could represent the fused
+        version, or the tiled version, of the provided ``loop_chain``; a sequence
+        of new :class:`ParLoop` objects using the fused/tiled kernels should be
+        returned.
         """
-        raise NotImplementedError("Subclass must implement instantiation of ParLoops")
+        raise NotImplementedError("Subclass must implement ``__call__`` method")
 
 
 class PlainSchedule(Schedule):
@@ -140,21 +446,21 @@ class PlainSchedule(Schedule):
     def __init__(self):
         super(PlainSchedule, self).__init__([])
 
-    def to_par_loop(self, loop_chain):
+    def __call__(self, loop_chain):
         return loop_chain
 
 
 class FusionSchedule(Schedule):
     """Schedule for a sequence of soft/hard fused :class:`ParLoop` objects."""
 
-    def __init__(self, kernels, ranges):
-        super(FusionSchedule, self).__init__(kernels)
+    def __init__(self, kernel, ranges):
+        super(FusionSchedule, self).__init__(kernel)
         self._ranges = ranges
 
-    def to_par_loop(self, loop_chain):
+    def __call__(self, loop_chain):
         offset = 0
         fused_par_loops = []
-        for kernel, range in zip(self._kernels, self._ranges):
+        for kernel, range in zip(self._kernel, self._ranges):
             iterset = loop_chain[offset].it_space.iterset
             args = flatten([loop.args for loop in loop_chain[offset:range]])
             fused_par_loops.append(par_loop(kernel, iterset, *args))
@@ -165,17 +471,18 @@ class FusionSchedule(Schedule):
 class TilingSchedule(Schedule):
     """Schedule for a sequence of tiled :class:`ParLoop` objects."""
 
-    def __init__(self, kernels, inspection):
-        super(TilingSchedule, self).__init__(kernels)
+    def __init__(self, schedule, inspection, executor):
+        self._schedule = schedule
         self._inspection = inspection
+        self._executor = executor
 
     def _filter_args(self, loop_chain):
         """Uniquify arguments and access modes"""
         args = OrderedDict()
         for loop in loop_chain:
             # 1) Analyze the Args in each loop composing the chain and produce a
-            # new sequence of Args for the tiled ParLoop. For example, consider the
-            # Arg X and X.DAT be written to in ParLoop_0 (access mode WRITE) and
+            # new sequence of Args for the tiled ParLoop. For example, consider
+            # Arg X, and be X.DAT written to in ParLoop_0 (access mode WRITE) and
             # read from in ParLoop_1 (access mode READ); this means that in the
             # tiled ParLoop, X will have access mode RW
             for a in loop.args:
@@ -184,25 +491,31 @@ class TilingSchedule(Schedule):
                     if READ in [a.access, args[a.data].access]:
                         # If a READ and some sort of write (MIN, MAX, RW, WRITE,
                         # INC), then the access mode becomes RW
-                        args[a.data] = a.data(RW, a.map, a._flatten)
+                        args[a.data]._access = RW
                     elif WRITE in [a.access, args[a.data].access]:
                         # Can't be a READ, so just stick to WRITE regardless of what
                         # the other access mode is
-                        args[a.data] = a.data(WRITE, a.map, a._flatten)
+                        args[a.data]._access = WRITE
                     else:
                         # Neither READ nor WRITE, so access modes are some
                         # combinations of RW, INC, MIN, MAX. For simplicity,
                         # just make it RW.
-                        args[a.data] = a.data(RW, a.map, a._flatten)
+                        args[a.data]._access = RW
         return args.values()
 
-    def _filter_itersets(self, loop_chain):
-        return [loop.it_space.iterset for loop in loop_chain]
-
-    def to_par_loop(self, loop_chain):
+    def __call__(self, loop_chain):
+        loop_chain = self._schedule(loop_chain)
         args = self._filter_args(loop_chain)
-        iterset = self._filter_itersets(loop_chain)
-        return [ParLoop(self._kernels, iterset, self._inspection, *args)]
+        kernel = tuple((loop.kernel for loop in loop_chain))
+        all_args = tuple((Arg.specialize(loop.args, gtl_map, i) for i, (loop, gtl_map)
+                         in enumerate(zip(loop_chain, self._executor.gtl_maps))))
+        it_space = tuple((loop.it_space for loop in loop_chain))
+        kwargs = {
+            'inspection': self._inspection,
+            'all_args': all_args,
+            'executor': self._executor
+        }
+        return [ParLoop(kernel, it_space, *args, **kwargs)]
 
 
 # Loop chain inspection
@@ -242,8 +555,8 @@ class Inspector(Cached):
         if self._initialized:
             return
         if not hasattr(self, '_inspected'):
-            # Initialization can occur more than once, but only the first time
-            # this attribute should be set
+            # Initialization can occur more than once (until the inspection is
+            # actually performed), but only the first time this attribute is set
             self._inspected = 0
         self._name = name
         self._tile_size = tile_size
@@ -336,67 +649,32 @@ class Inspector(Cached):
 
         from C. Bertolli et al.
         """
+        fuse = lambda fusing: par_loop(Kernel([l.kernel for l in fusing]),
+                                       fusing[0].it_space.iterset,
+                                       *flatten([l.args for l in fusing]))
 
-        def do_fuse(loop_a, loop_b, unique_id):
-            """Fuse ``loop_b`` into ``loop_a``. All symbols identifiers in
-            ``loop_b`` are modified appending the suffix ``unique_id``."""
-            kernel_a, kernel_b = loop_a.kernel, loop_b.kernel
-
-            # 1) Name and additional parameters of the fused kernel
-            name = 'fused_%s_%s' % (kernel_a._name, kernel_b._name)
-            opts = dict(kernel_a._opts.items() + kernel_b._opts.items())
-            include_dirs = kernel_a._include_dirs + kernel_b._include_dirs
-            headers = kernel_a._headers + kernel_b._headers
-            user_code = "\n".join([kernel_a._user_code, kernel_b._user_code])
-
-            # 2) Fuse the ASTs
-            fused_ast, ast_b = dcopy(kernel_a._ast), dcopy(kernel_b._ast)
-            fused_ast.name = name
-            # 2-A) Concatenate the arguments in the signature
-            fused_ast.args.extend(ast_b.args)
-            # 2-B) Uniquify symbols identifiers
-            ast_b_info = coffee_ast_visit(ast_b, None)
-            ast_b_decls = ast_b_info['decls']
-            ast_b_symbols = ast_b_info['symbols']
-            for str_sym, decl in ast_b_decls.items():
-                for symbol in ast_b_symbols.keys():
-                    coffee_ast_update_id(symbol, str_sym, unique_id)
-            # 2-C) Concatenate kernels' bodies
-            marker_ast_node = coffee_ast.FlatBlock("\n\n// Begin of fused kernel\n\n")
-            fused_ast.children[0].children.extend([marker_ast_node] + ast_b.children)
-
-            args = loop_a.args + loop_b.args
-            kernel = Kernel(fused_ast, name, opts, include_dirs, headers, user_code)
-            return par_loop(kernel, loop_a.it_space.iterset, *args)
-
-        # In the process of soft fusion, temporary "fake" ParLoops are constructed
-        # to simplify tracking of data dependencies.
-        # In the following, the word "range" indicates an offset in the original
-        # loop chain to represent of slice of original ParLoops that have been fused
-        fused_loops_ranges, fusing_loop_range = [], []
-        base_loop = self._loop_chain[0]
-        for i, loop in enumerate(self._loop_chain[1:], 1):
+        fused, fusing = [], [self._loop_chain[0]]
+        for i, loop in enumerate(self._loop_chain[1:]):
+            base_loop = fusing[-1]
             if base_loop.it_space != loop.it_space or \
                     (base_loop.is_indirect and loop.is_indirect):
                 # Fusion not legal
-                fused_loops_ranges.append((base_loop, i))
-                base_loop = loop
-                fusing_loop_range = []
-                continue
-            elif base_loop.is_direct and loop.is_direct:
-                base_loop = do_fuse(base_loop, loop, i)
-            elif base_loop.is_direct and loop.is_indirect:
-                base_loop = do_fuse(loop, base_loop, i)
-            elif base_loop.is_indirect and loop.is_direct:
-                base_loop = do_fuse(base_loop, loop, i)
-            fusing_loop_range = [(base_loop, i+1)]
-        fused_loops_ranges.extend(fusing_loop_range)
+                fused.append((fuse(fusing), i+1))
+                fusing = [loop]
+            elif (base_loop.is_direct and loop.is_direct) or \
+                    (base_loop.is_direct and loop.is_indirect) or \
+                    (base_loop.is_indirect and loop.is_direct):
+                # This loop is fusible. Also, can speculative go on searching
+                # for other loops to fuse
+                fusing.append(loop)
+            else:
+                raise RuntimeError("Unexpected loop chain structure while fusing")
+        if fusing:
+            fused.append((fuse(fusing), len(self._loop_chain)))
 
-        fused_loop_chain, ranges = zip(*fused_loops_ranges)
-        fused_kernels = [loop.kernel for loop in fused_loop_chain]
-
-        self._loop_chain = fused_loop_chain
-        self._schedule = FusionSchedule(fused_kernels, ranges)
+        fused_loops, offsets = zip(*fused)
+        self._loop_chain = fused_loops
+        self._schedule = FusionSchedule([l.kernel for l in fused_loops], offsets)
 
     def _tile(self):
         """Tile consecutive loops over different iteration sets characterized
@@ -406,27 +684,31 @@ class Inspector(Cached):
 
         # Build arguments types and values
         arguments = []
-        sets, maps, loops = set(), {}, []
+        insp_sets, insp_maps, insp_loops = set(), {}, []
         for loop in self._loop_chain:
             slope_desc = set()
             # Add sets
-            sets.add((loop.it_space.name, loop.it_space.core_size))
+            insp_sets.add((loop.it_space.name, loop.it_space.core_size))
             for a in loop.args:
-                map = a.map
-                # Add map
-                if map:
-                    maps[map.name] = (map.name, map.iterset.name,
-                                      map.toset.name, map.values)
-                # Track descriptors
-                desc_name = "DIRECT" if not a.map else a.map.name
-                desc_access = a.access._mode  # Note: same syntax as SLOPE
-                slope_desc.add((desc_name, desc_access))
+                maps = as_tuple(a.map, Map)
+                # Add maps (there can be more than one per argument if the arg
+                # is actually a Mat - in which case there are two maps - or if
+                # a MixedMap) and relative descriptors
+                if not maps:
+                    slope_desc.add(('DIRECT', a.access._mode))
+                    continue
+                for i, map in enumerate(maps):
+                    for j, m in enumerate(map):
+                        map_name = "%s%d_%d" % (m.name, i, j)
+                        insp_maps[m.name] = (map_name, m.iterset.name,
+                                             m.toset.name, m.values)
+                        slope_desc.add((map_name, a.access._mode))
             # Add loop
-            loops.append((loop.kernel.name, loop.it_space.name, list(slope_desc)))
+            insp_loops.append((loop.kernel.name, loop.it_space.name, list(slope_desc)))
         # Provide structure of loop chain to the SLOPE's inspector
-        inspector.add_sets(sets)
-        arguments.extend([inspector.add_maps(maps.values())])
-        inspector.add_loops(loops)
+        inspector.add_sets(insp_sets)
+        arguments.extend([inspector.add_maps(insp_maps.values())])
+        inspector.add_loops(insp_loops)
         # Get type and value of any additional arguments that the SLOPE's inspector
         # expects
         arguments.extend(inspector.set_external_dats())
@@ -438,28 +720,26 @@ class Inspector(Cached):
         src = inspector.generate_code()
 
         # Return type of the inspector
-        rettype = slope.Executor._ctype
+        rettype = slope.Executor.meta['py_ctype_exec']
 
         # Compiler and linker options
         slope_dir = os.environ['SLOPE_DIR']
         compiler = coffee.plan.compiler.get('name')
         cppargs = slope.get_compile_opts(compiler)
-        cppargs += ['-I%s/sparsetiling/include' % slope_dir]
-        ldargs = ['-L%s/lib' % slope_dir, '-l%s' % slope.get_lib_name()]
+        cppargs += ['-I%s/%s' % (slope_dir, slope.get_include_dir())]
+        ldargs = ['-L%s/%s' % (slope_dir, slope.get_lib_dir()),
+                  '-l%s' % slope.get_lib_name()]
 
         # Compile and run inspector
         fun = compilation.load(src, "cpp", "inspector", cppargs, ldargs,
                                argtypes, rettype, compiler)
         inspection = fun(*argvalues)
 
+        # Finally, get the Executor representation, to be used at executor's
+        # code generation time
         executor = slope.Executor(inspector)
 
-        # Generate executor C code
-        src = executor.generate_code()
-
-        # Create the Kernel object, which contains the executor code
-        kernel = Kernel(src, "executor")
-        self._schedule = TilingSchedule(kernel, inspection)
+        self._schedule = TilingSchedule(self._schedule, inspection, executor)
 
     @property
     def mode(self):
@@ -496,7 +776,7 @@ def reschedule_loops(name, loop_chain, tile_size, mode='tile'):
     # the cache, and obtain the fused ParLoops through the schedule it produces
     inspector = Inspector(name, loop_chain, tile_size)
     schedule = inspector.inspect(mode)
-    return schedule.to_par_loop(loop_chain)
+    return schedule(loop_chain)
 
 
 @contextmanager
@@ -540,5 +820,5 @@ def loop_chain(name, time_unroll=1, tile_size=0):
         trace[start_point:] = reschedule_loops(name, total_loop_chain, tile_size)
         loop_chain.unrolled_loop_chain = []
     else:
-        unrolled_loop_chain.extend(total_loop_chain)
+        loop_chain.unrolled_loop_chain.extend(total_loop_chain)
 loop_chain.unrolled_loop_chain = []

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -50,6 +50,7 @@ from mpi import collective
 from utils import flatten
 from op2 import par_loop, Kernel
 
+import coffee
 from coffee import base as coffee_ast
 from coffee.utils import visit as coffee_ast_visit, \
     ast_replace as coffee_ast_replace
@@ -203,11 +204,6 @@ class Inspector(object):
         by RAW and WAR dependencies. This requires interfacing with the SLOPE
         library."""
 
-        slope_dir = os.environ['SLOPE_DIR']
-        cppargs = slope.get_compile_opts()
-        cppargs += ['-I%s/sparsetiling/include' % slope_dir]
-        ldargs = ['-L%s/lib' % slope_dir, '-l%s' % slope.get_lib_name()]
-
         inspector = slope.Inspector('OMP', self._tile_size)
 
         # Build arguments types and values
@@ -244,6 +240,11 @@ class Inspector(object):
 
         # Generate inspector C code
         src = inspector.generate_code()
+
+        slope_dir = os.environ['SLOPE_DIR']
+        cppargs = slope.get_compile_opts(coffee.plan.compiler.get('name'), coords)
+        cppargs += ['-I%s/sparsetiling/include' % slope_dir]
+        ldargs = ['-L%s/lib' % slope_dir, '-l%s' % slope.get_lib_name()]
 
         fun = compilation.load(src, "cpp", "inspector", cppargs, ldargs,
                                argtypes, None, "intel")

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -235,20 +235,24 @@ class Inspector(object):
         if coords:
             arguments.extend([inspector.add_coords((coords.dataset.set.name,
                                                     coords._data, coords.shape[1]))])
-
         argtypes, argvalues = zip(*arguments)
 
         # Generate inspector C code
         src = inspector.generate_code()
 
+        # Return type of the inspector
+        rettype = slope.Executor._ctype
+
+        # Compile and line options
         slope_dir = os.environ['SLOPE_DIR']
-        cppargs = slope.get_compile_opts(coffee.plan.compiler.get('name'), coords)
+        compiler = coffee.plan.compiler.get('name')
+        cppargs = slope.get_compile_opts(compiler, coords)
         cppargs += ['-I%s/sparsetiling/include' % slope_dir]
         ldargs = ['-L%s/lib' % slope_dir, '-l%s' % slope.get_lib_name()]
 
         fun = compilation.load(src, "cpp", "inspector", cppargs, ldargs,
-                               argtypes, None, "intel")
-        fun(*argvalues, argtypes=argtypes, restype=None)
+                               argtypes, rettype, compiler)
+        c_executor = fun(*argvalues, argtypes=argtypes, restype=None)
 
 
 # Parallel loop API

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -651,6 +651,8 @@ class Inspector(Cached):
         with timed_region("ParLoopChain `%s`: inspector" % self._name):
             self._soft_fuse()
             if mode > 0:
+                self._hard_fuse()
+            if mode > 1:
                 self._tile()
 
         # A schedule has been computed by any of /_soft_fuse/, /_hard_fuse/ or
@@ -715,6 +717,12 @@ class Inspector(Cached):
         fused_loops, offsets = zip(*fused)
         self._loop_chain = fused_loops
         self._schedule = FusionSchedule([l.kernel for l in fused_loops], offsets)
+
+    def _hard_fuse(self):
+        """Fuse consecutive loops over different iteration sets that do not
+        present RAW or WAR dependencies. This requires interfacing with the
+        SLOPE library."""
+        hf = slope.HardFusion(self._loop_chain)()
 
     def _tile(self):
         """Tile consecutive loops over different iteration sets characterized

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -681,7 +681,7 @@ class Inspector(Cached):
         """Tile consecutive loops over different iteration sets characterized
         by RAW and WAR dependencies. This requires interfacing with the SLOPE
         library."""
-        inspector = slope.Inspector('OMP', self._tile_size)
+        inspector = slope.Inspector('OMP')
 
         # Build arguments types and values
         arguments = []
@@ -707,12 +707,15 @@ class Inspector(Cached):
             # Add loop
             insp_loops.append((loop.kernel.name, loop.it_space.name, list(slope_desc)))
         # Provide structure of loop chain to the SLOPE's inspector
-        inspector.add_sets(insp_sets)
+        arguments.extend([inspector.add_sets(insp_sets)])
         arguments.extend([inspector.add_maps(insp_maps.values())])
         inspector.add_loops(insp_loops)
         # Get type and value of any additional arguments that the SLOPE's inspector
         # expects
-        arguments.extend(inspector.set_external_dats())
+        arguments.extend([inspector.set_external_dats()])
+
+        # Set a specific tile size
+        arguments.extend([inspector.set_tile_size(self._tile_size)])
 
         # Arguments types and values
         argtypes, argvalues = zip(*arguments)

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -40,6 +40,7 @@ import os
 
 from base import _trace
 from base import *
+import base
 import openmp
 import compilation
 import host
@@ -183,7 +184,7 @@ class Kernel(openmp.Kernel, tuple):
         # Protect against re-initialization when retrieved from cache
         if self._initialized:
             return
-        kernels = as_tuple(kernels, (Kernel, host.Kernel))
+        kernels = as_tuple(kernels, (Kernel, host.Kernel, base.Kernel))
 
         Kernel._globalcount += 1
         self._kernels = kernels

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -1094,6 +1094,10 @@ def fuse(name, loop_chain, tile_size):
             any([l._reduced_globals for l in loop_chain]):
         return loop_chain
 
+    # Loop fusion requires modifying kernels, so ASTs must be present
+    if any([not l.kernel._ast for l in loop_chain]):
+        return loop_chain
+
     mode = 'hard'
     if tile_size > 0:
         mode = 'tile'

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -52,7 +52,6 @@ from utils import flatten, strip, as_tuple
 
 import coffee
 from coffee import base as ast
-from coffee.plan import ASTKernel
 from coffee.utils import visit as ast_visit, ast_c_make_alias as ast_make_alias
 
 import slope_python as slope

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -946,7 +946,7 @@ class Inspector(Cached):
             if_exec = ast.If(if_cond, [ast.Block([fuse_funcall, if_update],
                                                  open_scope=True)])
             fuse_body = ast.Block([if_exec], open_scope=True)
-            fuse_for = ast.c_for('i', fused_map.arity, fuse_body, pragma="")
+            fuse_for = ast.c_for('i', fused_map.arity, fuse_body, pragma=None)
             body.children.extend([base_funcall, fuse_for.children[0]])
 
             ### Modify the /fuse/ kernel ###
@@ -988,7 +988,7 @@ class Inspector(Cached):
                             ofs_vals.extend([init(o) for o in _ofs_vals])
                     # Tell COFFEE that the argument is not an empty buffer anymore,
                     # so any write to it must actually be an increment
-                    fuse_kernel_arg.pragma = [ast.INC]
+                    fuse_kernel_arg.pragma = set([ast.INC])
                 elif fuse_loop_arg._is_indirect:
                     # 2B) All indirect arguments. At the C level, these arguments
                     #     are of pointer type, so simple pointer arithmetic is used

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -1130,6 +1130,7 @@ def fuse(name, loop_chain, tile_size):
         * the function is invoked on a previoulsy fused ``loop_chain``
         * a global reduction is present;
         * tiling in enabled and at least one loop iterates over an extruded set
+        * mixed Dats are present (feature not supported yet)
     """
     if len(loop_chain) in [0, 1]:
         # Nothing to fuse
@@ -1155,6 +1156,10 @@ def fuse(name, loop_chain, tile_size):
 
     # Loop fusion requires modifying kernels, so ASTs must be present
     if any([not l.kernel._ast for l in loop_chain]):
+        return loop_chain
+
+    # Mixed still not supported
+    if any(a._is_mixed for a in flatten([l.args for l in loop_chain])):
         return loop_chain
 
     mode = 'hard'

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -54,8 +54,6 @@ import coffee
 from coffee import base as ast
 from coffee.utils import visit as ast_visit, ast_c_make_alias as ast_make_alias
 
-import slope_python as slope
-
 
 class Arg(host.Arg):
 
@@ -1203,7 +1201,10 @@ def fuse(name, loop_chain, tile_size):
         mode = 'tile'
         # Loop tiling requires the SLOPE library to be available on the system.
         try:
+            import slope_python as slope
             os.environ['SLOPE_DIR']
+        except ImportError:
+            warning("Requested tiling, but couldn't locate SLOPE. Check the PYTHONPATH")
         except KeyError:
             warning("Set the env variable SLOPE_DIR to the location of SLOPE")
             warning("Loops won't be fused, and plain ParLoops will be executed")

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -750,29 +750,29 @@ class Inspector(Cached):
             fuse_asts = [k._ast for k in kernels]
             # Fuse the actual kernels' bodies
             base_ast = dcopy(fuse_asts[0])
-            ast_info = ast_visit(base_ast, search=ast.FunDecl)
-            base_ast_fundecl = ast_info['search'][ast.FunDecl]
-            if len(base_ast_fundecl) != 1:
+            base_info = ast_visit(base_ast, search=ast.FunDecl)
+            base_fundecl = base_info['search'][ast.FunDecl]
+            if len(base_fundecl) != 1:
                 raise RuntimeError("Fusing kernels, but found unexpected AST")
-            base_ast_fundecl = base_ast_fundecl[0]
+            base_fundecl = base_fundecl[0]
             for unique_id, _fuse_ast in enumerate(fuse_asts[1:], 1):
                 fuse_ast = dcopy(_fuse_ast)
                 # 1) Extend function name
-                base_ast_fundecl.name = "%s_%s" % (base_ast.name, fuse_ast.name)
+                base_fundecl.name = "%s_%s" % (base_ast.name, fuse_ast.name)
                 # 2) Concatenate the arguments in the signature
-                base_ast_fundecl.args.extend(fuse_ast.args)
+                base_fundecl.args.extend(fuse_ast.args)
                 # 3) Uniquify symbols identifiers
-                fuse_ast_info = ast_visit(fuse_ast)
-                fuse_ast_decls = fuse_ast_info['decls']
-                fuse_ast_symbols = fuse_ast_info['symbols']
-                for str_sym, decl in fuse_ast_decls.items():
-                    for symbol in fuse_ast_symbols.keys():
+                fuse_info = ast_visit(fuse_ast)
+                fuse_decls = fuse_info['decls']
+                fuse_symbols = fuse_info['symbols']
+                for str_sym, decl in fuse_decls.items():
+                    for symbol in fuse_symbols.keys():
                         ast_update_id(symbol, str_sym, unique_id)
                 # 4) Concatenate bodies
                 marker = [ast.FlatBlock("\n\n// Begin of fused kernel\n\n")]
-                base_ast_fundecl.children[0].children.extend(marker + fuse_ast.children)
+                base_fundecl.children[0].children.extend(marker + fuse_ast.children)
             # Eliminate redundancies in the fused kernel's signature
-            self._filter_kernel_args(loops, base_ast_fundecl)
+            self._filter_kernel_args(loops, base_fundecl)
             # Naming convention
             fused_ast = base_ast
             return Kernel(kernels, fused_ast, loop_chain_index)

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -1217,7 +1217,7 @@ def fuse(name, loop_chain, tile_size):
 
 
 @contextmanager
-def loop_chain(name, time_unroll=1, tile_size=0):
+def loop_chain(name, num_unroll=1, tile_size=0):
     """Analyze the sub-trace of loops lazily evaluated in this contextmanager ::
 
         [loop_0, loop_1, ..., loop_n-1]
@@ -1233,11 +1233,11 @@ def loop_chain(name, time_unroll=1, tile_size=0):
     original trace slice.
 
     :param name: identifier of the loop chain
-    :param time_unroll: in a time stepping loop, the length of the loop chain
-                        is given by ``num_loops * time_unroll``, where ``num_loops``
-                        is the number of loops per time loop iteration. Therefore,
-                        setting this value to a number greater than 1 enables
-                        fusing/tiling longer loop chains (optional, defaults to 1).
+    :param num_unroll: in a time stepping loop, the length of the loop chain
+                       is given by ``num_loops * num_unroll``, where ``num_loops``
+                       is the number of loops per time loop iteration. Therefore,
+                       setting this value to a number greater than 1 enables
+                       fusing/tiling longer loop chains (optional, defaults to 1).
     :param tile_size: suggest a tile size in case loop tiling is used (optional).
                       If ``0`` is passed in, only soft fusion is performed.
     """
@@ -1247,15 +1247,15 @@ def loop_chain(name, time_unroll=1, tile_size=0):
 
     yield
 
-    if time_unroll < 1:
+    if num_unroll < 1:
         return
 
     start_point = trace.index(stamp[0])+1 if stamp else 0
     extracted_loop_chain = trace[start_point:]
 
-    # Unroll the loop chain ``time_unroll`` times before fusion/tiling
+    # Unroll the loop chain /num_unroll/ times before fusion/tiling
     total_loop_chain = loop_chain.unrolled_loop_chain + extracted_loop_chain
-    if len(total_loop_chain) / len(extracted_loop_chain) == time_unroll:
+    if len(total_loop_chain) / len(extracted_loop_chain) == num_unroll:
         start_point = trace.index(total_loop_chain[0])
         trace[start_point:] = fuse(name, total_loop_chain, tile_size)
         loop_chain.unrolled_loop_chain = []

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -1028,6 +1028,18 @@ class Inspector(Cached):
             fuse_funcall.children.extend(ofs_syms)
             fuse_fundecl.args.extend(ofs_decls)
 
+            # 2D) Hard fusion breaks any padding applied to the /fuse/ kernel, so
+            # this transformation pass needs to be re-performed;
+            if fuse._code:
+                opts = {'compiler': fuse._opts['compiler'],
+                        'simd_isa': fuse._opts['simd_isa'],
+                        'align_pad': True}
+                ast_handler = ASTKernel(fuse_fundecl, fuse._include_dirs)
+                ast_handler.plan_cpu(opts)
+            if base._code:
+                base._opts = {'compiler': fuse._opts['compiler'],
+                              'simd_isa': fuse._opts['simd_isa']}
+
             # Create a /fusion.Kernel/ object to be used to update the schedule
             fused_headers = set([str(h) for h in base_headers + fuse_headers])
             fused_ast = ast.Root([ast.PreprocessNode(h) for h in fused_headers] +

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -1179,7 +1179,7 @@ def fuse(name, loop_chain, tile_size):
         return loop_chain + remainder
 
     # Loop fusion requires modifying kernels, so ASTs must be present
-    if any([not l.kernel._ast for l in loop_chain]):
+    if any([not hasattr(l.kernel, '_ast') or not l.kernel._ast for l in loop_chain]):
         return loop_chain + remainder
 
     # Mixed still not supported

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -40,7 +40,6 @@ import os
 
 from base import *
 import base
-import openmp
 import compilation
 import host
 from backends import _make_object
@@ -58,11 +57,8 @@ from coffee.utils import visit as coffee_ast_visit, \
 
 import slope_python as slope
 
-# hard coded value to max openmp threads
-_max_threads = 32
 
-
-class Arg(openmp.Arg):
+class Arg(host.Arg):
 
     @staticmethod
     def specialize(args, gtl_map, loop_id):
@@ -139,7 +135,7 @@ class Arg(openmp.Arg):
         return "arg_exec_loop%d_%d" % (self._loop_position, self._position)
 
 
-class Kernel(openmp.Kernel, tuple):
+class Kernel(host.Kernel, tuple):
 
     """A :class:`fusion.Kernel` object represents an ordered sequence of kernels.
     The sequence can either be the result of the concatenation of the kernels
@@ -243,7 +239,7 @@ class Kernel(openmp.Kernel, tuple):
 
 # Parallel loop API
 
-class JITModule(openmp.JITModule):
+class JITModule(host.JITModule):
 
     _cppargs = []
     _libraries = []
@@ -401,7 +397,7 @@ for (int n = %(tile_start)s; n < %(tile_end)s; n++) {
         return code_dict
 
 
-class ParLoop(openmp.ParLoop):
+class ParLoop(host.ParLoop):
 
     def __init__(self, kernel, it_space, *args, **kwargs):
         read_args = [a.data for a in args if a.access in [READ, RW]]

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -566,9 +566,9 @@ class TilingSchedule(Schedule):
 class Inspector(Cached):
     """An inspector is used to fuse or tile a sequence of :class:`ParLoop` objects.
 
-    The inspector is implemented by the SLOPE library, which the user makes
-    visible by setting the environment variable ``SLOPE_DIR`` to the value of
-    the root SLOPE directory."""
+    For tiling, the inspector exploits the SLOPE library, which the user makes
+    visible by setting the environment variable ``SLOPE_DIR`` to the root SLOPE
+    directory."""
 
     _cache = {}
     _modes = ['soft', 'hard', 'tile']
@@ -579,6 +579,7 @@ class Inspector(Cached):
         for loop in loop_chain:
             if isinstance(loop, Mat._Assembly):
                 continue
+            key += (hash(str(loop.kernel._ast)),)
             for arg in loop.args:
                 if arg._is_global:
                     key += (arg.data.dim, arg.data.dtype, arg.access)

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -167,7 +167,7 @@ class Kernel(host.Kernel, tuple):
         :param fused_ast: the Abstract Syntax Tree of the fused kernel. If not
                           provided, kernels are simply concatenated.
         :param loop_chain_index: index (i.e., position) of the kernel in a loop
-                                 chain. This can be used to differentiate a same
+                                 chain. This can be used to identify the same
                                  kernel appearing multiple times in a loop chain.
         """
         # Protect against re-initialization when retrieved from cache
@@ -731,8 +731,8 @@ class Inspector(Cached):
         kernel bodies and creating new :class:`ParLoop` objects representing
         the fused sequence.
 
-        The conditions under which two loops over the same iteration set are
-        hardly fused are:
+        The conditions under which two loops over the same iteration set can
+        be hard fused are:
 
             * They are both direct, OR
             * One is direct and the other indirect
@@ -821,7 +821,7 @@ class Inspector(Cached):
                      ...)
 
         where ``dat_1_1 == dat_2_1`` and, possibly (but not necessarily),
-        ``it_space_1 != it_space_2``, can be hardly fused. Note, in fact, that
+        ``it_space_1 != it_space_2``, can be hard fused. Note, in fact, that
         the presence of ``INC`` does not imply a real WAR dependency, because
         increments are associative."""
 
@@ -875,7 +875,7 @@ class Inspector(Cached):
             return
 
         # Then, create a suitable hard-fusion kernel
-        # The hardly-fused kernel will have the following structure:
+        # The hard fused kernel will have the following structure:
         #
         # wrapper (args: Union(kernel1, kernel2, extra):
         #   staging of pointers
@@ -952,7 +952,7 @@ class Inspector(Cached):
             ### Modify the /fuse/ kernel ###
             # This is to take into account that many arguments are shared with
             # /base/, so they will only staged once for /base/. This requires
-            # tweaking the way the arguments are declared and accessed in /fuse/'s
+            # tweaking the way the arguments are declared and accessed in /fuse/
             # kernel. For example, the shared incremented array (called /buffer/
             # in the pseudocode in the comment above) now needs to take offsets
             # to be sure the locations that /base/ is supposed to increment are
@@ -966,7 +966,7 @@ class Inspector(Cached):
                     # 2A) The shared incremented argument. A 'buffer' of statically
                     #     known size is expected by the kernel, so the offset is used
                     #     to index into it
-                    # Note: the /fused_map/ is a factor of the /base/'s iteration
+                    # Note: the /fused_map/ is a factor of the /base/ iteration
                     # set map, so the order the /fuse/ loop's iterations are
                     # executed (in the /for i=0 to arity/ loop) reflects the order
                     # of the entries in /fused_map/
@@ -992,7 +992,7 @@ class Inspector(Cached):
                 elif fuse_loop_arg._is_indirect:
                     # 2B) All indirect arguments. At the C level, these arguments
                     #     are of pointer type, so simple pointer arithmetic is used
-                    #     to ensure the kernel's accesses are to the correct locations
+                    #     to ensure the kernel accesses are to the correct locations
                     fuse_arity = fuse_loop_arg.map.arity
                     base_arity = fuse_arity*fused_map.arity
                     cdim = fuse_loop_arg.data.dataset.cdim
@@ -1017,7 +1017,7 @@ class Inspector(Cached):
                         ofs_assigns += [ast.Assign(ast.Symbol(ofs_tmp, (j,)),
                                                    ast.Symbol(sym_id, (k,)))
                                         for j, k in enumerate(ofs_idx_syms)]
-                        # Need to reflect this onto /fuse/'s invocation
+                        # Need to reflect this onto the invocation of /fuse/
                         fuse_funcall.children[fuse_loop.args.index(fuse_loop_arg)] = \
                             ast.Symbol(ofs_tmp)
                     else:
@@ -1125,7 +1125,7 @@ class Inspector(Cached):
                                argtypes, rettype, compiler)
         inspection = fun(*argvalues)
 
-        # Finally, get the Executor representation, to be used at executor's
+        # Finally, get the Executor representation, to be used at executor
         # code generation time
         executor = slope.Executor(inspector)
 

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -764,9 +764,9 @@ class Inspector(Cached):
                 # 3) Uniquify symbols identifiers
                 fuse_info = ast_visit(fuse_ast)
                 fuse_decls = fuse_info['decls']
-                fuse_symbols = fuse_info['symbols']
+                fuse_symbols = fuse_info['symbol_refs']
                 for str_sym, decl in fuse_decls.items():
-                    for symbol in fuse_symbols.keys():
+                    for symbol, _ in fuse_symbols[str_sym]:
                         ast_update_id(symbol, str_sym, unique_id)
                 # 4) Concatenate bodies
                 marker = [ast.FlatBlock("\n\n// Begin of fused kernel\n\n")]

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -87,9 +87,10 @@ class Arg(host.Arg):
             _arg._c_local_maps = c_local_maps
             return _arg
 
-        if isinstance(args, (list, tuple)):
+        try:
             return [convert(arg, gtl_map, loop_id) for arg in args]
-        return convert(args, gtl_map, loop_id)
+        except TypeError:
+            return convert(args, gtl_map, loop_id)
 
     @staticmethod
     def filter_args(loop_args):
@@ -731,7 +732,7 @@ class Inspector(Cached):
         the fused sequence.
 
         The conditions under which two loops over the same iteration set can
-        be hard fused are:
+        be soft fused are:
 
             * They are both direct, OR
             * One is direct and the other indirect

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -179,7 +179,6 @@ class Kernel(host.Kernel, tuple):
         self._name = "_".join([k.name for k in kernels])
         self._opts = dict(flatten([k._opts.items() for k in kernels]))
         self._applied_blas = any(k._applied_blas for k in kernels)
-        self._applied_ap = any(k._applied_ap for k in kernels)
         self._include_dirs = list(set(flatten([k._include_dirs for k in kernels])))
         self._headers = list(set(flatten([k._headers for k in kernels])))
         self._user_code = "\n".join(list(set([k._user_code for k in kernels])))

--- a/pyop2/fusion.py
+++ b/pyop2/fusion.py
@@ -31,7 +31,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""OP2 OpenMP backend for fused/tiled loops."""
+"""OP2 backend for fusion and tiling of ``ParLoops``."""
 
 from contextlib import contextmanager
 from collections import OrderedDict

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -595,6 +595,7 @@ class JITModule(base.JITModule):
 
     _cppargs = []
     _libraries = []
+    _extension = 'c'
 
     def __init__(self, kernel, itspace, *args, **kwargs):
         """
@@ -711,10 +712,11 @@ class JITModule(base.JITModule):
         if configuration["debug"]:
             self._wrapper_code = code_to_compile
 
-        extension = "c"
-        cppargs = ["-I%s/include" % d for d in get_petsc_dir()] + \
-                  ["-I%s" % d for d in self._kernel._include_dirs] + \
-                  ["-I%s" % os.path.abspath(os.path.dirname(__file__))]
+        extension = self._extension
+        cppargs = self._cppargs
+        cppargs += ["-I%s/include" % d for d in get_petsc_dir()] + \
+                   ["-I%s" % d for d in self._kernel._include_dirs] + \
+                   ["-I%s" % os.path.abspath(os.path.dirname(__file__))]
         if compiler:
             cppargs += [compiler[coffee.plan.intrinsics['inst_set']]]
         ldargs = ["-L%s/lib" % d for d in get_petsc_dir()] + \

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -41,7 +41,7 @@ import compilation
 from base import *
 from mpi import collective
 from configuration import configuration
-from utils import as_tuple
+from utils import as_tuple, strip
 
 import coffee.plan
 from coffee import base as ast
@@ -645,8 +645,6 @@ class JITModule(base.JITModule):
         # If we weren't in the cache we /must/ have arguments
         if not hasattr(self, '_args'):
             raise RuntimeError("JITModule has no args associated with it, should never happen")
-        strip = lambda code: '\n'.join([l for l in code.splitlines()
-                                        if l.strip() and l.strip() != ';'])
 
         # Attach semantical information to the kernel's AST
         if self._kernel._ast:

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -54,9 +54,13 @@ class Kernel(base.Kernel):
     def _ast_to_c(self, ast, opts={}):
         """Transform an Abstract Syntax Tree representing the kernel into a
         string of code (C syntax) suitable to CPU execution."""
+        # Protect against re-transformation when retrieved from cache
+        if opts.get('transformed'):
+            return ast.gencode()
         ast_handler = ASTKernel(ast, self._include_dirs)
         ast_handler.plan_cpu(opts)
         self._applied_blas = ast_handler.blas
+        opts['transformed'] = True
         return ast_handler.gencode()
 
 

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -678,7 +678,7 @@ class JITModule(base.JITModule):
             %(externc_open)s
             %(code)s
             #undef OP2_STRIDE
-            """ % {'code': self._kernel.code,
+            """ % {'code': self._kernel.code(),
                    'externc_open': externc_open,
                    'namespace': blas_namespace,
                    'header': headers}
@@ -688,7 +688,7 @@ class JITModule(base.JITModule):
             %(namespace)s
             %(externc_open)s
             %(code)s
-            """ % {'code': self._kernel.code,
+            """ % {'code': self._kernel.code(),
                    'externc_open': externc_open,
                    'namespace': blas_namespace,
                    'header': headers}

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -46,7 +46,7 @@ from utils import as_tuple, strip
 import coffee.plan
 from coffee import base as ast
 from coffee.plan import ASTKernel
-from coffee.utils import get_fun_decls as ast_get_fun_decls
+from coffee.utils import visit as ast_visit
 
 
 class Kernel(base.Kernel):
@@ -649,9 +649,10 @@ class JITModule(base.JITModule):
 
         # Attach semantical information to the kernel's AST
         if self._kernel._ast:
-            fundecl = ast_get_fun_decls(self._kernel._ast)
-            if fundecl:
-                for arg, f_arg in zip(self._args, fundecl.args):
+            ast_info = ast_visit(self._kernel._ast, search=ast.FunDecl)
+            fundecl = ast_info['search'][ast.FunDecl]
+            if len(fundecl) == 1:
+                for arg, f_arg in zip(self._args, fundecl[0].args):
                     if arg._uses_itspace and arg._is_INC:
                         f_arg.pragma = ast.WRITE
 

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -55,12 +55,12 @@ class Kernel(base.Kernel):
         """Transform an Abstract Syntax Tree representing the kernel into a
         string of code (C syntax) suitable to CPU execution."""
         # Protect against re-transformation when retrieved from cache
-        if opts.get('transformed'):
+        if self._opts.get('transformed'):
             return ast.gencode()
         ast_handler = ASTKernel(ast, self._include_dirs)
-        ast_handler.plan_cpu(opts)
+        ast_handler.plan_cpu(self._opts)
         self._applied_blas = ast_handler.blas
-        opts['transformed'] = True
+        self._opts['transformed'] = True
         return ast_handler.gencode()
 
 

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -45,9 +45,7 @@ from configuration import configuration
 from utils import as_tuple, strip
 
 import coffee.plan
-from coffee import base as ast
 from coffee.plan import ASTKernel
-from coffee.utils import visit as ast_visit
 
 
 class Kernel(base.Kernel):

--- a/pyop2/utils.py
+++ b/pyop2/utils.py
@@ -308,6 +308,10 @@ def trim(docstring):
     return '\n'.join(trimmed)
 
 
+def strip(code):
+    return '\n'.join([l for l in code.splitlines() if l.strip() and l.strip() != ';'])
+
+
 def get_petsc_dir():
     try:
         arch = '/' + os.environ.get('PETSC_ARCH', '')

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -2028,7 +2028,7 @@ class TestKernelAPI:
     def test_kernel_repr(self, backend, set):
         "Kernel should have the expected repr."
         k = op2.Kernel("int foo() { return 0; }", 'foo')
-        assert repr(k) == 'Kernel("""%s""", %r)' % (k.code, k.name)
+        assert repr(k) == 'Kernel("""%s""", %r)' % (k.code(), k.name)
 
     def test_kernel_str(self, backend, set):
         "Kernel should have the expected string representation."


### PR DESCRIPTION
This PR introduces loop fusion in PyOP2. 

Bad news:
- It depends on three other branches (in FFC, COFFEE, and Firedrake)
- It obviously passes all tests, including Firedrake ones (with fusion enabled), but of course this should be tested extensively in bigger codes
- It's quite massive...

Good news:
- ...but the changes are mostly confined in a new module, fusion.py and...
- ...fusion is off by default, but one can switch it on by simply exporting PYOP2_LOOP_FUSION=1. I think this is the best scheme for the moment, so incrementally we can fix bugs and add functionalities. This also ensures no performance regression (if any).
- performance evaluation will be the next step
- anyway, I haven't experienced any tangible overhead due to fusing loops

Other minor points:
- extrusion and mixed are currently not supported in "hard fusion mode" (see below). It's a matter of fixing code generation, which I'll do after some performance experimentation

How it works (summary):
- it's all based on lazy evaluation of loops. If fusion is ON, the trace of loops is intercepted prior to execution and analysed
- three sort of fusions are possible, depending on the actual data dependency pattern between loops: 
  * if no dependency at all or only "trivial" ones are present (e.g., two *direct* loops, write-after-read or read-after-writ), then ``soft fusion`` is performed: that's basically body concatenation, plus a few minor tweaks (e.g. avoiding passing in the same Arg twice, etc.). 
  * if dependencies are less trivial, like increment-after-increment in indirect loops (the case of cell/facet integrals in Firedrake), then what I called ``hard fusion`` takes place. Things here get more complicated, because basically one needs to track which elements of the fused loop (e.g. cells) have already been visited to avoid executing the same iteration multiple times. This is not the only issue though -- however, the code is fairly commented, so if interested I invite to have a look at it.
  * if dependencies are "real dependencies", like read-after-write between indirect loops. then fusion is implemented through ``split tiling``. For this, an ``inspector-executor scheme`` is implemented exploiting the SLOPE library (accessible at coneoproject/SLOPE).  This is an under-development feature: it currently works if one explicitly enabled it,  but still far we are from actually being able of extensively using it (for example, it lacks MPI support).

Details on the implementation:
- Polymorphism is exploited extensively
- Fusion is heavily based on caching. The fused kernels, the data dependency analysis etc, are all performed just once for identical sequences of loops

Required branches/PR:
- PR 39 in coneoproject/COFFEE
-  PR 492 in firedrakeproject/firedrake
- PR 72 in bitbucket.org/mapdes/ffc