### PR TITLE
Copy class variables into instance in JITModule

### DIFF
--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -622,6 +622,9 @@ class JITModule(base.JITModule):
         self._direct = kwargs.get('direct', False)
         self._iteration_region = kwargs.get('iterate', ALL)
         self._initialized = True
+        # Copy the class variables, so we don't overwrite them
+        self._cppargs = dcopy(type(self)._cppargs)
+        self._libraries = dcopy(type(self)._libraries)
 
     @collective
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
We append to the cppargs and libraries list when compiling, so don't use
the class variable directly.