### PR TITLE
Replace maybe_set_dat_dirty on GPU backends

### DIFF
--- a/pyop2/cuda.py
+++ b/pyop2/cuda.py
@@ -925,7 +925,6 @@ class ParLoop(op2.ParLoop):
                 # Data state is updated in finalise_reduction for Global
                 if arg.access is not op2.READ:
                     arg.data.state = DeviceDataMixin.DEVICE
-        self.maybe_set_dat_dirty()
 
 
 _device = None

--- a/pyop2/opencl.py
+++ b/pyop2/opencl.py
@@ -739,7 +739,6 @@ class ParLoop(device.ParLoop):
         for arg in self.args:
             if arg.access is not READ:
                 arg.data.state = DeviceDataMixin.DEVICE
-        self.maybe_set_dat_dirty()
 
         for a in self._all_global_reduction_args:
             a.data._post_kernel_reduction_task(conf['work_group_count'], a.access)


### PR DESCRIPTION
A refactoring (OP2/PyOP2@7657a4be3343255cd45ead4a70b99387d6be6f18) changed
maybe_set_dat_dirty to update_arg_data_state this updates the name in
for cuda.py and opencl.py