### PR TITLE
Fix sparsity alloc

### DIFF
--- a/test/unit/test_matrices.py
+++ b/test/unit/test_matrices.py
@@ -612,6 +612,24 @@ class TestMatrices:
         mat.inc_local_diagonal_entries(range(nrows))
         assert (mat.values == np.identity(nrows * n)).all()
 
+    def test_mat_always_has_diagonal_space(self, backend):
+        # A sparsity should always have space for diagonal entries
+        s = op2.Set(1)
+        d = op2.Set(4)
+        m = op2.Map(s, d, 1, [2])
+        d2 = op2.Set(3)
+        m2 = op2.Map(s, d2, 1, [1])
+        sparsity = op2.Sparsity((d, d2), (m, m2))
+
+        from petsc4py import PETSc
+        # petsc4py default error handler swallows SETERRQ, so just
+        # install the abort handler to notice an error.
+        PETSc.Sys.pushErrorHandler("abort")
+        mat = op2.Mat(sparsity)
+        PETSc.Sys.popErrorHandler()
+
+        assert np.allclose(mat.handle.getDiagonal().array, 0.0)
+
     def test_minimal_zero_mat(self, backend, skip_cuda):
         """Assemble a matrix that is all zeros."""
 

--- a/test/unit/test_matrices.py
+++ b/test/unit/test_matrices.py
@@ -579,7 +579,6 @@ class TestSparsity:
             m = op2.Map(s, s, 1)
             op2.Sparsity((s, s), (m, m))
 
-    @pytest.mark.xfail(reason="Broken")
     def test_sparsity_always_has_diagonal_space(self, backend):
         # A sparsity should always have space for diagonal entries
         s = op2.Set(1)

--- a/test/unit/test_matrices.py
+++ b/test/unit/test_matrices.py
@@ -579,6 +579,18 @@ class TestSparsity:
             m = op2.Map(s, s, 1)
             op2.Sparsity((s, s), (m, m))
 
+    @pytest.mark.xfail(reason="Broken")
+    def test_sparsity_always_has_diagonal_space(self, backend):
+        # A sparsity should always have space for diagonal entries
+        s = op2.Set(1)
+        d = op2.Set(4)
+        m = op2.Map(s, d, 1, [2])
+        d2 = op2.Set(5)
+        m2 = op2.Map(s, d2, 2, [1, 4])
+        sparsity = op2.Sparsity((d, d2), (m, m2))
+
+        assert all(sparsity.nnz == [1, 1, 3, 1])
+
 
 class TestMatrices:
 


### PR DESCRIPTION
My recent refactorings broke the allocation of always having a diagonal entry.  This fixes that, and adds a tests that the sparsity is the right size and building a matrix on it works.