### PR TITLE
(Re)-add ParLoop Kernel timer in sequential backend

### DIFF
--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -40,6 +40,7 @@ from exceptions import *
 import host
 from mpi import collective
 from petsc_base import *
+from profiling import timed_region
 from host import Kernel, Arg  # noqa: needed by BackendSelector
 from utils import as_tuple, cached_property
 
@@ -158,7 +159,8 @@ class ParLoop(host.ParLoop):
 
     @collective
     def _compute(self, part, fun, *arglist):
-        fun(part.offset, part.offset + part.size, *arglist)
+        with timed_region("ParLoop kernel"):
+            fun(part.offset, part.offset + part.size, *arglist)
 
 
 def _setup():


### PR DESCRIPTION
Is it okay to put this back? It was removed in 16fa81178fb6e8209f28bcc7091b30b6f4008737 but I can't tell if it was deliberate or not, the other backends still seem to have this timer (e.g. https://github.com/OP2/PyOP2/blob/master/pyop2/opencl.py#L552).