### PR TITLE
Add option to check if code differs across processes

### DIFF
--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -46,6 +46,10 @@ class Configuration(dict):
         `opencl`, `openmp` or `sequential`).
     :param debug: Turn on debugging for generated code (turns off
         compiler optimisations).
+    :param type_check: Should PyOP2 type-check API-calls?  (Default,
+        yes)
+    :param check_src_hashes: Should PyOP2 check that generated code is
+        the same on all processes?  (Default, no).
     :param log_level: How chatty should PyOP2 be?  Valid values
         are "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL".
     :param lazy_evaluation: Should lazy evaluation be on or off?
@@ -72,6 +76,7 @@ class Configuration(dict):
         "blas": ("PYOP2_BLAS", str, ""),
         "debug": ("PYOP2_DEBUG", int, 0),
         "type_check": ("PYOP2_TYPE_CHECK", bool, True),
+        "check_src_hashes": ("PYOP2_CHECK_SRC_HASHES", bool, False),
         "log_level": ("PYOP2_LOG_LEVEL", (str, int), "WARNING"),
         "lazy_evaluation": ("PYOP2_LAZY", bool, True),
         "lazy_max_trace_length": ("PYOP2_MAX_TRACE_LENGTH", int, 100),


### PR DESCRIPTION
If configuration["check_src_hashes"] is True (or, as before
configuration["debug"] is True) then verify that all processes are
indeed trying to compile the same code.