### PR TITLE
Assembly cache fix

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2301,6 +2301,10 @@ class MixedDat(Dat):
         """Return :class:`Dat` with index ``idx`` or a given slice of Dats."""
         return self._dats[idx]
 
+    @property
+    def _version(self):
+        return tuple(x._version for x in self.split)
+
     @cached_property
     def dtype(self):
         """The NumPy dtype of the data."""

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3949,7 +3949,7 @@ class ParLoop(LazyComputation):
                    ('iterset', Set, SetTypeError))
     def __init__(self, kernel, iterset, *args, **kwargs):
         LazyComputation.__init__(self,
-                                 set([a.data for a in args if a.access in [READ, RW]]) | Const._defs,
+                                 set([a.data for a in args if a.access in [READ, RW, INC]]) | Const._defs,
                                  set([a.data for a in args if a.access in [RW, WRITE, MIN, MAX, INC]]),
                                  set([a.data for a in args if a.access in [INC]]))
         # INCs into globals need to start with zero and then sum back

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1966,8 +1966,9 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
         # Set up the copy to happen when required.
         other._cow_parloop = self._copy_parloop(other)
         # Remove the write dependency of the copy (in order to prevent
-        # premature execution of the loop).
-        other._cow_parloop.writes = set()
+        # premature execution of the loop), and replace it with the
+        # one dat we're writing to.
+        other._cow_parloop.writes = set([other])
         if configuration['lazy_evaluation']:
             # In the lazy case, we enqueue now to ensure we are at the
             # right point in the trace.

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1942,8 +1942,10 @@ class Dat(SetAssociated, _EmptyDataMixin, CopyOnWrite):
         # Force the execution of the copy parloop
 
         # We need to ensure that PyOP2 allocates fresh storage for this copy.
+        # But only if the copy has not already run.
         try:
-            del self._numpy_data
+            if self._numpy_data is src._numpy_data:
+                del self._numpy_data
         except AttributeError:
             pass
 

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2412,14 +2412,14 @@ class MixedDat(Dat):
         # Force the execution of the copy parloop
 
         for d, s in zip(self._dats, src._dats):
-            d._cow_actual_copy(d, s)
+            d._cow_actual_copy(s)
 
     @collective
     def _cow_shallow_copy(self):
 
         other = shallow_copy(self)
 
-        other._dats = [d._cow_shallow_copy() for d in self._dats]
+        other._dats = [d.duplicate() for d in self._dats]
 
         return other
 

--- a/pyop2/versioning.py
+++ b/pyop2/versioning.py
@@ -68,7 +68,7 @@ class Versioned(object):
 
     def __new__(cls, *args, **kwargs):
         obj = super(Versioned, cls).__new__(cls)
-        obj._version = 1
+        obj.__version = 1
         obj._version_before_zero = 1
         return obj
 
@@ -78,12 +78,16 @@ class Versioned(object):
 
         self._version_before_zero += 1
         # Undo_version = 0
-        self._version = self._version_before_zero
+        self.__version = self._version_before_zero
 
     def _version_set_zero(self):
         """Set the data version of this object to zero (usually when
         self.zero() is called)."""
-        self._version = 0
+        self.__version = 0
+
+    @property
+    def _version(self):
+        return self.__version
 
 
 def _force_copies(obj):

--- a/test/unit/test_versioning.py
+++ b/test/unit/test_versioning.py
@@ -146,6 +146,24 @@ class TestVersioning:
         x += 1
         assert not s.is_valid()
 
+    def test_mixed_dat_versioning(self, backend, x, y):
+        md = op2.MixedDat([x, y])
+        mdv = md._version
+        x += 1
+        assert md._version != mdv
+        mdv1 = md._version
+        y += 1
+        assert md._version != mdv1
+        assert md._version != mdv
+        mdv2 = md._version
+        md.zero()
+        assert md._version == (0, 0)
+        y += 2
+        assert md._version != mdv2
+        assert md._version != mdv1
+        assert md._version != mdv
+        assert md._version != (0, 0)
+
 
 class TestCopyOnWrite:
     @pytest.fixture

--- a/test/unit/test_versioning.py
+++ b/test/unit/test_versioning.py
@@ -203,6 +203,36 @@ class TestCopyOnWrite:
         assert all(x_dup.data_ro == numpy.arange(nelems) + 1)
         assert all(x.data_ro == numpy.arange(nelems))
 
+    def test_CoW_MixedDat_duplicate_original_changes(self, backend, x, y):
+        md = op2.MixedDat([x, y])
+        md_dup = md.duplicate()
+        x += 1
+        y += 2
+        for a, b in zip(md, md_dup):
+            assert not self.same_data(a, b)
+
+        assert numpy.allclose(md_dup.data_ro[0], numpy.arange(nelems))
+        assert numpy.allclose(md_dup.data_ro[1], 0)
+
+        assert numpy.allclose(md.data_ro[0], numpy.arange(nelems) + 1)
+        assert numpy.allclose(md.data_ro[1], 2)
+
+    def test_CoW_MixedDat_duplicate_copy_changes(self, backend, x, y):
+        md = op2.MixedDat([x, y])
+        md_dup = md.duplicate()
+        x_dup = md_dup[0]
+        y_dup = md_dup[1]
+        x_dup += 1
+        y_dup += 2
+        for a, b in zip(md, md_dup):
+            assert not self.same_data(a, b)
+
+        assert numpy.allclose(md_dup.data_ro[0], numpy.arange(nelems) + 1)
+        assert numpy.allclose(md_dup.data_ro[1], 2)
+
+        assert numpy.allclose(md.data_ro[0], numpy.arange(nelems))
+        assert numpy.allclose(md.data_ro[1], 0)
+
     def test_CoW_mat_duplicate_original_changes(self, backend, mat, skip_cuda, skip_opencl):
         mat_dup = mat.duplicate()
         mat.zero_rows([0], 1.0)


### PR DESCRIPTION
Addresses a number of long-running assembly cache bugs in Firedrake.  In particular, appears to fix firedrakeproject/firedrake#319 firedrakeproject/firedrake#386 and firedrakeproject/firedrake#541.

However, I'm still not sure these are all correct fixes.  I basically do not understand the interaction of all the pieces fully.