### PR TITLE
No sane way to set compiler flags as a user.

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -60,8 +60,10 @@ class Compiler(object):
     :arg ld: Linker executable (optional, if ``None``, we assume the compiler
         can build object files and link in a single invocation, can be
         overridden by exporting the environment variable ``LDSHARED``).
-    :arg cppargs: A list of arguments to the C compiler (optional).
-    :arg ldargs: A list of arguments to the linker (optional).
+    :arg cppargs: A list of arguments to the C compiler (optional, prepended to
+        any flags specified as the cflags configuration option)
+    :arg ldargs: A list of arguments to the linker (optional, prepended to any
+        flags specified as the ldflags configuration option).
     :arg cpp: Should we try and use the C++ compiler instead of the C
         compiler?.
     :kwarg comm: Optional communicator to compile the code on (only
@@ -72,8 +74,8 @@ class Compiler(object):
         ccenv = 'CXX' if cpp else 'CC'
         self._cc = os.environ.get(ccenv, cc)
         self._ld = os.environ.get('LDSHARED', ld)
-        self._cppargs = cppargs
-        self._ldargs = ldargs
+        self._cppargs = cppargs + configuration['cflags'].split()
+        self._ldargs = ldargs + configuration['ldflags'].split()
         self.comm = comm or COMM_WORLD
 
     @collective

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -38,7 +38,7 @@ import sys
 import ctypes
 from hashlib import md5
 from configuration import configuration
-from logger import progress, INFO
+from logger import debug, progress, INFO
 from exceptions import CompilationError
 
 
@@ -139,6 +139,7 @@ class Compiler(object):
                     if self._ld is None:
                         cc = [self._cc] + self._cppargs + \
                              ['-o', tmpname, cname] + self._ldargs
+                        debug('Compilation command: %s', ' '.join(cc))
                         with file(logfile, "w") as log:
                             with file(errfile, "w") as err:
                                 log.write("Compilation command:\n")
@@ -164,6 +165,8 @@ Compile errors in %s""" % (e.cmd, e.returncode, logfile, errfile))
                         cc = [self._cc] + self._cppargs + \
                              ['-c', '-o', oname, cname]
                         ld = self._ld.split() + ['-o', tmpname, oname] + self._ldargs
+                        debug('Compilation command: %s', ' '.join(cc))
+                        debug('Link command: %s', ' '.join(ld))
                         with file(logfile, "w") as log:
                             with file(errfile, "w") as err:
                                 log.write("Compilation command:\n")

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -44,6 +44,10 @@ class Configuration(dict):
 
     :param backend: Select the PyOP2 backend (one of `cuda`,
         `opencl`, `openmp` or `sequential`).
+    :param compiler: compiler identifier used by COFFEE (one of `gnu`, `intel`).
+    :param simd_isa: Instruction set architecture (ISA) COFFEE is optimising
+        for (one of `sse`, `avx`).
+    :param blas: COFFEE BLAS backend (one of `mkl`, `atlas`, `eigen`).
     :param debug: Turn on debugging for generated code (turns off
         compiler optimisations).
     :param type_check: Should PyOP2 type-check API-calls?  (Default,

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -48,6 +48,8 @@ class Configuration(dict):
     :param simd_isa: Instruction set architecture (ISA) COFFEE is optimising
         for (one of `sse`, `avx`).
     :param blas: COFFEE BLAS backend (one of `mkl`, `atlas`, `eigen`).
+    :param cflags: extra flags to be passed to the C compiler.
+    :param ldflags: extra flags to be passed to the linker.
     :param debug: Turn on debugging for generated code (turns off
         compiler optimisations).
     :param type_check: Should PyOP2 type-check API-calls?  (Default,
@@ -81,6 +83,9 @@ class Configuration(dict):
         "compiler": ("PYOP2_BACKEND_COMPILER", str, "gnu"),
         "simd_isa": ("PYOP2_SIMD_ISA", str, "sse"),
         "debug": ("PYOP2_DEBUG", bool, False),
+        "blas": ("PYOP2_BLAS", str, ""),
+        "cflags": ("PYOP2_CFLAGS", str, ""),
+        "ldflags": ("PYOP2_LDFLAGS", str, ""),
         "type_check": ("PYOP2_TYPE_CHECK", bool, True),
         "check_src_hashes": ("PYOP2_CHECK_SRC_HASHES", bool, True),
         "log_level": ("PYOP2_LOG_LEVEL", (str, int), "WARNING"),


### PR DESCRIPTION
Patrick (rightly) comments that there's no sane way to modify the default set of compiler flags.  Either from pyop2 directly or through firedrake.  There should be.