### PR TITLE
Fix parallel compilation

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -79,12 +79,13 @@ class Compiler(object):
         basename = hsh.hexdigest()
 
         cachedir = configuration['cache_dir']
-        cname = os.path.join(cachedir, "%s.%s" % (basename, extension))
-        oname = os.path.join(cachedir, "%s.o" % basename)
+        pid = os.getpid()
+        cname = os.path.join(cachedir, "%s_p%d.%s" % (basename, pid, extension))
+        oname = os.path.join(cachedir, "%s_p%d.o" % (basename, pid))
         soname = os.path.join(cachedir, "%s.so" % basename)
         # Link into temporary file, then rename to shared library
         # atomically (avoiding races).
-        tmpname = os.path.join(cachedir, "%s.so.tmp" % basename)
+        tmpname = os.path.join(cachedir, "%s_p%d.so.tmp" % (basename, pid))
 
         if configuration['check_src_hashes'] or configuration['debug']:
             basenames = MPI.comm.allgather(basename)
@@ -108,8 +109,8 @@ class Compiler(object):
                 # No need to do this on all ranks
                 if not os.path.exists(cachedir):
                     os.makedirs(cachedir)
-                logfile = os.path.join(cachedir, "%s.log" % basename)
-                errfile = os.path.join(cachedir, "%s.err" % basename)
+                logfile = os.path.join(cachedir, "%s_p%d.log" % (basename, pid))
+                errfile = os.path.join(cachedir, "%s_p%d.err" % (basename, pid))
                 with progress(INFO, 'Compiling wrapper'):
                     with file(cname, "w") as f:
                         f.write(src)


### PR DESCRIPTION
Running the Firedrake test suite takes a lot of time. Running them in parallel makes in faster, but annoyingly a few random failures always appear when running the test suite in parallel with a clean cache. This pull request - I claim - fixes that problem.

Implementation ideas:
 * Make sure that no two processes writes the same file at a time by adding the process ID to the file name.
 * To still share files between processes, we rename the final file to have a process-independent name. This should be safe, as POSIX requires file moves to be atomic.