### PR TITLE
Hardcode offsets in semi-structured wrappers

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -4228,19 +4228,6 @@ class ParLoop(LazyComputation):
         return [arg for arg in self.args if arg._is_global_reduction]
 
     @cached_property
-    def offset_args(self):
-        """The offset args that need to be added to the argument list."""
-        _args = []
-        for arg in self.args:
-            if arg._is_indirect or arg._is_mat:
-                maps = as_tuple(arg.map, Map)
-                for map in maps:
-                    for m in map:
-                        if m.iterset._extruded:
-                            _args.append(m.offset)
-        return _args
-
-    @cached_property
     def layer_arg(self):
         """The layer arg that needs to be added to the argument list."""
         if self._is_layered:

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3856,7 +3856,7 @@ class JITModule(Cached):
                     idx = (arg.idx.__class__, arg.idx.index)
                 else:
                     idx = arg.idx
-                map_arity = arg.map.arity if arg.map else None
+                map_arity = arg.map and (tuplify(arg.map.offset) or arg.map.arity)
                 if arg._is_dat_view:
                     view_idx = arg.data.index
                 else:
@@ -3866,7 +3866,8 @@ class JITModule(Cached):
             elif arg._is_mat:
                 idxs = (arg.idx[0].__class__, arg.idx[0].index,
                         arg.idx[1].index)
-                map_arities = (arg.map[0].arity, arg.map[1].arity)
+                map_arities = (tuplify(arg.map[0].offset) or arg.map[0].arity,
+                               tuplify(arg.map[1].offset) or arg.map[1].arity)
                 # Implicit boundary conditions (extruded "top" or
                 # "bottom") affect generated code, and therefore need
                 # to be part of cache key

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -408,20 +408,18 @@ class Arg(base.Arg):
         for i, (m, d) in enumerate(zip(self.map, self.data)):
             for k in range(d.cdim if self._flatten else 1):
                 for idx in range(m.arity):
-                    val.append("%(name)s[%(j)d] += %(offset)s[%(i)d] * %(dim)s;" %
+                    val.append("%(name)s[%(j)d] += %(offset)d * %(dim)s;" %
                                {'name': self.c_vec_name(),
-                                'i': idx,
                                 'j': vec_idx,
-                                'offset': self.c_offset_name(i, 0),
+                                'offset': m.offset[idx],
                                 'dim': d.cdim})
                     vec_idx += 1
                 if is_facet:
                     for idx in range(m.arity):
-                        val.append("%(name)s[%(j)d] += %(offset)s[%(i)d] * %(dim)s;" %
+                        val.append("%(name)s[%(j)d] += %(offset)d * %(dim)s;" %
                                    {'name': self.c_vec_name(),
-                                    'i': idx,
                                     'j': vec_idx,
-                                    'offset': self.c_offset_name(i, 0),
+                                    'offset': m.offset[idx],
                                     'dim': d.cdim})
                         vec_idx += 1
         return '\n'.join(val)+'\n'
@@ -587,33 +585,30 @@ for ( int i = 0; i < %(dim)s; i++ ) %(combine)s;
                 for idx in range(m.arity):
                     if self._is_dat and self._flatten and d.cdim > 1:
                         for k in range(d.cdim):
-                            val.append("xtr_%(name)s[%(ind_flat)s] += %(off)s[%(ind)s] * %(dim)s;" %
+                            val.append("xtr_%(name)s[%(ind_flat)s] += %(off)d * %(dim)s;" %
                                        {'name': self.c_map_name(i, j),
-                                        'off': self.c_offset_name(i, j),
-                                        'ind': idx,
+                                        'off': m.offset[idx],
                                         'ind_flat': m.arity * k + idx,
                                         'dim': d.cdim})
                     else:
-                        val.append("xtr_%(name)s[%(ind)s] += %(off)s[%(ind)s];" %
+                        val.append("xtr_%(name)s[%(ind)s] += %(off)d;" %
                                    {'name': self.c_map_name(i, j),
-                                    'off': self.c_offset_name(i, j),
+                                    'off': m.offset[idx],
                                     'ind': idx})
                 if is_facet:
                     for idx in range(m.arity):
                         if self._is_dat and self._flatten and d.cdim > 1:
                             for k in range(d.cdim):
-                                val.append("xtr_%(name)s[%(ind_flat)s] += %(off)s[%(ind)s] * %(dim)s;" %
+                                val.append("xtr_%(name)s[%(ind_flat)s] += %(off)d * %(dim)s;" %
                                            {'name': self.c_map_name(i, j),
-                                            'off': self.c_offset_name(i, j),
-                                            'ind': idx,
+                                            'off': m.offset[idx],
                                             'ind_flat': m.arity * (k + d.cdim) + idx,
                                             'dim': d.cdim})
                         else:
-                            val.append("xtr_%(name)s[%(ind)s] += %(off)s[%(ind_zero)s];" %
+                            val.append("xtr_%(name)s[%(ind)s] += %(off)d;" %
                                        {'name': self.c_map_name(i, j),
-                                        'off': self.c_offset_name(i, j),
-                                        'ind': m.arity + idx,
-                                        'ind_zero': idx})
+                                        'off': m.offset[idx],
+                                        'ind': m.arity + idx})
         return '\n'.join(val)+'\n'
 
     def c_offset_init(self):

--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -877,8 +877,6 @@ class JITModule(base.JITModule):
         _layer_arg = ""
         if self._itspace._extruded:
             _layer_arg = ", int start_layer, int end_layer"
-            _off_args = ''.join([arg.c_offset_init() for arg in self._args
-                                 if arg._uses_itspace or arg._is_vec_map])
             _map_decl += ';\n'.join([arg.c_map_decl(is_facet=is_facet)
                                      for arg in self._args if arg._uses_itspace])
             _map_init += ';\n'.join([arg.c_map_init(is_top=is_top, layers=self._itspace.layers, is_facet=is_facet)
@@ -891,8 +889,6 @@ class JITModule(base.JITModule):
                                          for arg in self._args if arg._is_vec_map])
             _extr_loop = '\n' + extrusion_loop()
             _extr_loop_close = '}\n'
-        else:
-            _off_args = ""
 
         # Build kernel invocation. Let X be a parameter of the kernel representing a
         # tensor accessed in an iteration space. Let BUFFER be an array of the same
@@ -999,7 +995,6 @@ class JITModule(base.JITModule):
                 'const_args': _const_args,
                 'const_inits': indent(_const_inits, 1),
                 'vec_inits': indent(_vec_inits, 2),
-                'off_args': _off_args,
                 'layer_arg': _layer_arg,
                 'map_decl': indent(_map_decl, 2),
                 'vec_decs': indent(_vec_decs, 2),

--- a/pyop2/openmp.py
+++ b/pyop2/openmp.py
@@ -144,7 +144,6 @@ void %(wrapper_name)s(int boffset,
                       %(ssinds_arg)s
                       %(wrapper_args)s
                       %(const_args)s
-                      %(off_args)s
                       %(layer_arg)s) {
   %(user_code)s
   %(wrapper_decs)s;
@@ -192,7 +191,6 @@ void %(wrapper_name)s(int boffset,
         """
         argtypes = [ctypes.c_int, ctypes.c_int,                      # start end
                     ctypes.c_voidp, ctypes.c_voidp, ctypes.c_voidp]  # plan args
-        offset_args = []
         if isinstance(iterset, Subset):
             argtypes.append(iterset._argtype)
         for arg in args:
@@ -206,13 +204,9 @@ void %(wrapper_name)s(int boffset,
                 for map in maps:
                     for m in map:
                         argtypes.append(m._argtype)
-                        if m.iterset._extruded:
-                            offset_args.append(ctypes.c_voidp)
 
         for c in Const._definitions():
             argtypes.append(c._argtype)
-
-        argtypes.extend(offset_args)
 
         if iterset._extruded:
             argtypes.append(ctypes.c_int)
@@ -243,7 +237,6 @@ class ParLoop(device.ParLoop, host.ParLoop):
 
     def prepare_arglist(self, iterset, *args):
         arglist = []
-        offset_args = []
 
         if isinstance(iterset, Subset):
             arglist.append(iterset._indices.ctypes.data)
@@ -258,12 +251,8 @@ class ParLoop(device.ParLoop, host.ParLoop):
                 for map in maps:
                     for m in map:
                         arglist.append(m._values.ctypes.data)
-                        if m.iterset._extruded:
-                            offset_args.append(m.offset.ctypes.data)
         for c in Const._definitions():
             arglist.append(c._data.ctypes.data)
-
-        arglist.extend(offset_args)
 
         if iterset._extruded:
             region = self.iteration_region

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -52,7 +52,6 @@ void %(wrapper_name)s(int start, int end,
                       %(ssinds_arg)s
                       %(wrapper_args)s
                       %(const_args)s
-                      %(off_args)s
                       %(layer_arg)s) {
   %(user_code)s
   %(wrapper_decs)s;
@@ -78,7 +77,6 @@ void %(wrapper_name)s(int start, int end,
 
     def set_argtypes(self, iterset, *args):
         argtypes = [ctypes.c_int, ctypes.c_int]
-        offset_args = []
         if isinstance(iterset, Subset):
             argtypes.append(iterset._argtype)
         for arg in args:
@@ -92,13 +90,9 @@ void %(wrapper_name)s(int start, int end,
                 for map in maps:
                     for m in map:
                         argtypes.append(m._argtype)
-                        if m.iterset._extruded:
-                            offset_args.append(ctypes.c_voidp)
 
         for c in Const._definitions():
             argtypes.append(c._argtype)
-
-        argtypes.extend(offset_args)
 
         if iterset._extruded:
             argtypes.append(ctypes.c_int)
@@ -111,7 +105,6 @@ class ParLoop(host.ParLoop):
 
     def prepare_arglist(self, iterset, *args):
         arglist = []
-        offset_args = []
         if isinstance(iterset, Subset):
             arglist.append(iterset._indices.ctypes.data)
 
@@ -127,13 +120,9 @@ class ParLoop(host.ParLoop):
                 for map in arg._map:
                     for m in map:
                         arglist.append(m._values.ctypes.data)
-                        if m.iterset._extruded:
-                            offset_args.append(m.offset.ctypes.data)
 
         for c in Const._definitions():
             arglist.append(c._data.ctypes.data)
-
-        arglist.extend(offset_args)
 
         if iterset._extruded:
             region = self.iteration_region

--- a/pyop2/utils.py
+++ b/pyop2/utils.py
@@ -68,7 +68,7 @@ class cached_property(object):
 def as_tuple(item, type=None, length=None):
     # Empty list if we get passed None
     if item is None:
-        t = []
+        t = ()
     else:
         # Convert iterable to list...
         try:
@@ -97,6 +97,14 @@ def as_type(obj, typ):
             return np.float64(obj).astype(typ)
         else:
             raise TypeError("Invalid type %s" % type(obj))
+
+
+def tuplify(xs):
+    """Turn a data structure into a tuple tree."""
+    try:
+        return tuple(tuplify(x) for x in xs)
+    except TypeError:
+        return xs
 
 
 class validate_base:


### PR DESCRIPTION
This change hardcodes the offset values of the structured dimension in the wrapper.

@wence-: Please have a look at f26939b. I use the whole map in the key instead of just replacing arity with the offset array. This might be too discriminating? However, if it is equivalent to adding the individual components by hand, than I prefer this simpler version.