### PR TITLE
Flush assembly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 env:
   global:
     - C_INCLUDE_PATH=/usr/lib/openmpi/include
-    - PETSC_CONFIGURE_OPTIONS="--download-ctetgen --download-triangle --download-chaco"
+    - PETSC_CONFIGURE_OPTIONS="--download-ctetgen --download-triangle --download-chaco --with-debugging=1"
 # command to install dependencies
 before_install:
   - sudo apt-get update -qq

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3539,6 +3539,35 @@ class Sparsity(ObjectCached):
         return False
 
 
+class _LazyMatOp(LazyComputation):
+    """A lazily evaluated operation on a :class:`Mat`
+
+    :arg mat: The :class:`Mat` this operation touches
+    :arg closure: a callable piece of code to run
+    :arg new_state: What is the assembly state of the matrix after running
+         the closure?
+    :kwarg read:  Does this operation have read semantics?
+    :kwarg write:  Does this operation have write semantics?
+    :kwarg state: The state of the matrix after calling ``closure``.
+    """
+
+    def __init__(self, mat, closure, new_state, read=False, write=False):
+        read = [mat] if read else []
+        write = [mat] if write else []
+        super(_LazyMatOp, self).__init__(reads=read, writes=write, incs=[])
+        self._closure = closure
+        self._mat = mat
+        self._new_state = new_state
+
+    def _run(self):
+        if self._mat.assembly_state is not Mat.ASSEMBLED and \
+           self._new_state is not Mat.ASSEMBLED and \
+           self._new_state is not self._mat.assembly_state:
+            self._mat._flush_assembly()
+        self._closure()
+        self._mat.assembly_state = self._new_state
+
+
 class Mat(SetAssociated):
     """OP2 matrix data. A ``Mat`` is defined on a sparsity pattern and holds a value
     for each element in the :class:`Sparsity`.
@@ -3562,6 +3591,10 @@ class Mat(SetAssociated):
        :meth:`assemble` to finalise the writes.
     """
 
+    ASSEMBLED = "ASSEMBLED"
+    INSERT_VALUES = "INSERT_VALUES"
+    ADD_VALUES = "ADD_VALUES"
+
     _globalcount = 0
     _modes = [WRITE, INC]
 
@@ -3571,6 +3604,7 @@ class Mat(SetAssociated):
         self._sparsity = sparsity
         self._datatype = np.dtype(dtype)
         self._name = name or "mat_%d" % Mat._globalcount
+        self.assembly_state = Mat.ASSEMBLED
         Mat._globalcount += 1
 
     @validate_in(('access', _modes, ModeValueError))
@@ -3583,24 +3617,14 @@ class Mat(SetAssociated):
         return _make_object('Arg', data=self, map=path_maps, access=access,
                             idx=path_idxs, flatten=flatten)
 
-    class _Assembly(LazyComputation):
-        """Finalise assembly of this matrix.
-
-        Called lazily after user calls :meth:`assemble`"""
-        def __init__(self, mat):
-            super(Mat._Assembly, self).__init__(reads=mat, writes=mat, incs=mat)
-            self._mat = mat
-
-        def _run(self):
-            self._mat._assemble()
-
     def assemble(self):
         """Finalise this :class:`Mat` ready for use.
 
         Call this /after/ executing all the par_loops that write to
         the matrix before you want to look at it.
         """
-        Mat._Assembly(self).enqueue()
+        _LazyMatOp(self, self._assemble, new_state=Mat.ASSEMBLED,
+                   read=True, write=True).enqueue()
 
     def _assemble(self):
         raise NotImplementedError(
@@ -3673,6 +3697,11 @@ class Mat(SetAssociated):
     @cached_property
     def _is_vector_field(self):
         return not self._is_scalar_field
+
+    def _flush_assembly(self):
+        """Flush the in flight assembly operations (used when
+        switching between inserting and adding values."""
+        pass
 
     @property
     def values(self):
@@ -4180,8 +4209,10 @@ class ParLoop(LazyComputation):
                 if arg.data._is_allocated:
                     for d in arg.data:
                         d._data.setflags(write=False)
-            if arg._is_mat:
-                arg.data._needs_assembly = True
+            if arg._is_mat and arg.access is not READ:
+                state = {WRITE: Mat.INSERT_VALUES,
+                         INC: Mat.ADD_VALUES}[arg.access]
+                arg.data.assembly_state = state
 
     @cached_property
     def dat_args(self):

--- a/pyop2/petsc_base.py
+++ b/pyop2/petsc_base.py
@@ -397,12 +397,28 @@ class MatBlock(base.Mat):
         colis = cset.local_ises[j]
         self.handle = parent.handle.getLocalSubMatrix(isrow=rowis,
                                                       iscol=colis)
+        self._assembly_state = self._parent.assembly_state
+
+    @property
+    def assembly_state(self):
+        # Track our assembly state only
+        return self._assembly_state
+
+    @assembly_state.setter
+    def assembly_state(self, state):
+        # Need to update our state and our parent's
+        self._assembly_state = state
+        self._parent.assembly_state = state
 
     def __getitem__(self, idx):
         return self
 
     def __iter__(self):
         yield self
+
+    def _flush_assembly(self):
+        self.handle.assemble(assembly=PETSc.Mat.AssemblyType.FLUSH)
+        self._parent._flush_assembly()
 
     def set_local_diagonal_entries(self, rows, diag_val=1.0, idx=None):
         rows = np.asarray(rows, dtype=PETSc.IntType)
@@ -416,32 +432,40 @@ class MatBlock(base.Mat):
             else:
                 rows = np.dstack([rbs*rows + i for i in range(rbs)]).flatten()
         vals = np.repeat(diag_val, len(rows))
-        self.handle.setValuesLocalRCV(rows.reshape(-1, 1), rows.reshape(-1, 1),
-                                      vals.reshape(-1, 1),
-                                      addv=PETSc.InsertMode.INSERT_VALUES)
+        closure = lambda: self.handle.setValuesLocalRCV(rows.reshape(-1, 1),
+                                                        rows.reshape(-1, 1),
+                                                        vals.reshape(-1, 1),
+                                                        addv=PETSc.InsertMode.INSERT_VALUES)
+        base._LazyMatOp(self, closure, new_state=Mat.INSERT_VALUES,
+                        write=True).enqueue()
 
     def addto_values(self, rows, cols, values):
         """Add a block of values to the :class:`Mat`."""
-
-        self.handle.setValuesBlockedLocal(rows, cols, values,
-                                          addv=PETSc.InsertMode.ADD_VALUES)
-        self._needs_assembly = True
+        closure = lambda: self.handle.setValuesBlockedLocal(rows, cols, values,
+                                                            addv=PETSc.InsertMode.ADD_VALUES)
+        base._LazyMatOp(self, closure, new_state=Mat.ADD_VALUES,
+                        read=True, write=True).enqueue()
 
     def set_values(self, rows, cols, values):
         """Set a block of values in the :class:`Mat`."""
-
-        self.handle.setValuesBlockedLocal(rows, cols, values,
-                                          addv=PETSc.InsertMode.INSERT_VALUES)
-        self._needs_assembly = True
+        closure = lambda: self.handle.setValuesBlockedLocal(rows, cols, values,
+                                                            addv=PETSc.InsertMode.INSERT_VALUES)
+        base._LazyMatOp(self, closure, new_state=Mat.INSERT_VALUES,
+                        write=True).enqueue()
 
     def assemble(self):
-        pass
+        raise RuntimeError("Should never call assemble on MatBlock")
+
+    def _assemble(self):
+        raise RuntimeError("Should never call _assemble on MatBlock")
 
     @property
     def values(self):
         rset, cset = self._parent.sparsity.dsets
         rowis = rset.field_ises[self._i]
         colis = cset.field_ises[self._j]
+        base._trace.evaluate(set([self._parent]), set())
+        self._parent.assemble()
         mat = self._parent.handle.getSubMatrix(isrow=rowis,
                                                iscol=colis)
         return mat[:, :]
@@ -465,8 +489,8 @@ class Mat(base.Mat, CopyOnWrite):
     def __init__(self, *args, **kwargs):
         base.Mat.__init__(self, *args, **kwargs)
         CopyOnWrite.__init__(self, *args, **kwargs)
-        self._needs_assembly = False
         self._init()
+        self.assembly_state = Mat.ASSEMBLED
 
     @collective
     def _init(self):
@@ -623,6 +647,7 @@ class Mat(base.Mat, CopyOnWrite):
 
         :param rows: a :class:`Subset` or an iterable"""
         base._trace.evaluate(set([self]), set([self]))
+        self._assemble()
         rows = rows.indices if isinstance(rows, Subset) else rows
         self.handle.zeroRowsLocal(rows, diag_val)
 
@@ -630,6 +655,9 @@ class Mat(base.Mat, CopyOnWrite):
         base._trace.evaluate(set([src]), set())
         self.handle = src.handle.duplicate(copy=True)
         return self
+
+    def _flush_assembly(self):
+        self.handle.assemble(assembly=PETSc.Mat.AssemblyType.FLUSH)
 
     @modifies
     @collective
@@ -653,34 +681,41 @@ class Mat(base.Mat, CopyOnWrite):
             else:
                 rows = np.dstack([rbs*rows + i for i in range(rbs)]).flatten()
         vals = np.repeat(diag_val, len(rows))
-        self.handle.setValuesLocalRCV(rows.reshape(-1, 1), rows.reshape(-1, 1),
-                                      vals.reshape(-1, 1),
-                                      addv=PETSc.InsertMode.INSERT_VALUES)
-        self._needs_assembly = True
+        closure = lambda: self.handle.setValuesLocalRCV(rows.reshape(-1, 1),
+                                                        rows.reshape(-1, 1),
+                                                        vals.reshape(-1, 1),
+                                                        addv=PETSc.InsertMode.INSERT_VALUES)
+        base._LazyMatOp(self, closure, new_state=Mat.INSERT_VALUES,
+                        write=True).enqueue()
 
     @collective
     def _assemble(self):
+        # If the matrix is nested, we need to check each subblock to
+        # see if it needs assembling.  But if it's monolithic then the
+        # subblock assembly doesn't do anything, so we don't do that.
         if self.sparsity.nested:
             for m in self:
-                if m._needs_assembly:
+                if m.assembly_state is not Mat.ASSEMBLED:
                     m.handle.assemble()
-                    m._needs_assembly = False
-            return
-        self.handle.assemble()
+                m.assembly_state = Mat.ASSEMBLED
+        # Instead, we assemble the full monolithic matrix.
+        if self.assembly_state is not Mat.ASSEMBLED:
+            self.handle.assemble()
+            self.assembly_state = Mat.ASSEMBLED
 
     def addto_values(self, rows, cols, values):
         """Add a block of values to the :class:`Mat`."""
-
-        self.handle.setValuesBlockedLocal(rows, cols, values,
-                                          addv=PETSc.InsertMode.ADD_VALUES)
-        self._needs_assembly = True
+        closure = lambda: self.handle.setValuesBlockedLocal(rows, cols, values,
+                                                            addv=PETSc.InsertMode.ADD_VALUES)
+        base._LazyMatOp(self, closure, new_state=Mat.ADD_VALUES,
+                        read=True, write=True).enqueue()
 
     def set_values(self, rows, cols, values):
         """Set a block of values in the :class:`Mat`."""
-
-        self.handle.setValuesBlockedLocal(rows, cols, values,
-                                          addv=PETSc.InsertMode.INSERT_VALUES)
-        self._needs_assembly = True
+        closure = lambda: self.handle.setValuesBlockedLocal(rows, cols, values,
+                                                            addv=PETSc.InsertMode.INSERT_VALUES)
+        base._LazyMatOp(self, closure, new_state=Mat.INSERT_VALUES,
+                        write=True).enqueue()
 
     @cached_property
     def blocks(self):
@@ -691,7 +726,6 @@ class Mat(base.Mat, CopyOnWrite):
     @modifies
     def values(self):
         base._trace.evaluate(set([self]), set())
-        self._assemble()
         if self.nrows * self.ncols > 1000000:
             raise ValueError("Printing dense matrix with more than 1 million entries not allowed.\n"
                              "Are you sure you wanted to do this?")

--- a/pyop2/pyparloop.py
+++ b/pyop2/pyparloop.py
@@ -182,3 +182,16 @@ class ParLoop(base.ParLoop):
             # out of date.
             if arg._is_dat and isinstance(arg.data, device.Dat):
                 arg.data.state = device.DeviceDataMixin.HOST
+            if arg._is_mat and arg.access is not base.READ:
+                # Queue up assembly of matrix
+                arg.data.assemble()
+                # Now force the evaluation of everything.  Python
+                # parloops are not performance critical, so this is
+                # fine.
+                # We need to do this because the
+                # set_values/addto_values calls are lazily evaluated,
+                # and the parloop is already lazily evaluated so this
+                # lazily spawns lazy computation and getting
+                # everything to execute in the right order is
+                # otherwise madness.
+                arg.data._force_evaluation(read=True, write=False)

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -1415,25 +1415,6 @@ class TestMatAPI:
         with pytest.raises(exceptions.ModeValueError):
             mat(mode, (m_iterset_toset[op2.i[0]], m_iterset_toset[op2.i[1]]))
 
-    def test_mat_set_diagonal(self, backend, diag_mat, dat, skip_cuda):
-        """Setting the diagonal of a zero matrix."""
-        diag_mat.zero()
-        diag_mat.set_diagonal(dat)
-        assert np.allclose(diag_mat.handle.getDiagonal().array, dat.data_ro)
-
-    def test_mat_dat_mult(self, backend, diag_mat, dat, skip_cuda):
-        """Mat multiplied with Dat should perform matrix-vector multiplication
-        and yield a Dat."""
-        diag_mat.set_diagonal(dat)
-        assert np.allclose((diag_mat * dat).data_ro, np.multiply(dat.data_ro, dat.data_ro))
-
-    def test_mat_vec_mult(self, backend, diag_mat, dat, skip_cuda):
-        """Mat multiplied with PETSc Vec should perform matrix-vector
-        multiplication and yield a Dat."""
-        with dat.vec_ro as vec:
-            diag_mat.set_diagonal(vec)
-            assert np.allclose((diag_mat * vec).data_ro, np.multiply(dat.data_ro, dat.data_ro))
-
     def test_mat_iter(self, backend, mat):
         "Mat should be iterable and yield self."
         for m in mat:

--- a/test/unit/test_matrices.py
+++ b/test/unit/test_matrices.py
@@ -795,13 +795,6 @@ class TestMatrices:
         """Check that the matrix uses the amount of memory we expect."""
         assert mat.nbytes == 14 * 8
 
-    @pytest.mark.xfail('config.getvalue("backend") and config.getvalue("backend")[0] == "cuda"')
-    def test_set_diagonal(self, backend, x, mat):
-        mat.zero()
-        mat.set_diagonal(x)
-        for i, v in enumerate(x.data_ro):
-            assert mat.handle[i, i] == v
-
 
 class TestMixedMatrices:
     """
@@ -895,22 +888,6 @@ class TestMixedMatrices:
         eps = 1.e-12
         assert_allclose(dat[0].data_ro, b[0].data_ro, eps)
         assert_allclose(dat[1].data_ro, b[1].data_ro, eps)
-
-    @pytest.mark.xfail(reason="Assembling directly into mixed mats unsupported")
-    def test_set_diagonal(self, backend, mat, dat):
-        mat.zero()
-        mat.set_diagonal(dat)
-        rows, cols = mat.sparsity.shape
-        for i in range(rows):
-            if i < cols:
-                for j, v in enumerate(dat[i].data_ro):
-                    assert mat[i, i].handle[j, j] == v
-
-    @pytest.mark.xfail(reason="Assembling directly into mixed mats unsupported")
-    def test_set_diagonal_invalid_dat(self, backend, mat, mset):
-        dat = op2.MixedDat(mset ** 4)
-        with pytest.raises(TypeError):
-            mat.set_diagonal(dat)
 
 
 if __name__ == '__main__':

--- a/test/unit/test_matrices.py
+++ b/test/unit/test_matrices.py
@@ -526,6 +526,11 @@ def msparsity(mset, mmap):
 
 
 @pytest.fixture
+def non_nest_mixed_sparsity(mset, mmap):
+    return op2.Sparsity(mset, mmap, nest=False)
+
+
+@pytest.fixture
 def mvsparsity(mset, mmap):
     return op2.Sparsity(mset ** 2, mmap)
 
@@ -670,6 +675,7 @@ class TestMatrices:
     def test_assemble_mat(self, backend, mass, mat, coords, elements,
                           elem_node, expected_matrix):
         """Assemble a simple finite-element matrix and check the result."""
+        mat.zero()
         op2.par_loop(mass, elements,
                      mat(op2.INC, (elem_node[op2.i[0]], elem_node[op2.i[1]])),
                      coords(op2.READ, elem_node))
@@ -709,6 +715,7 @@ class TestMatrices:
         """Test accessing a scalar matrix with the WRITE access by adding some
         non-zero values into the matrix, then setting them back to zero with a
         kernel using op2.WRITE"""
+        mat.zero()
         op2.par_loop(kernel_inc, elements,
                      mat(op2.INC, (elem_node[op2.i[0]], elem_node[op2.i[1]])),
                      g(op2.READ))
@@ -794,6 +801,90 @@ class TestMatrices:
     def test_mat_nbytes(self, backend, mat):
         """Check that the matrix uses the amount of memory we expect."""
         assert mat.nbytes == 14 * 8
+
+
+class TestMatrixStateChanges:
+
+    """
+    Test that matrix state changes are correctly tracked.  Only used
+    on CPU backends (since it matches up with PETSc).
+    """
+
+    backends = ['sequential', 'openmp']
+
+    @pytest.fixture(params=[False, True],
+                    ids=["Non-nested", "Nested"])
+    def mat(self, request, msparsity, non_nest_mixed_sparsity):
+        if request.param:
+            mat = op2.Mat(msparsity)
+        else:
+            mat = op2.Mat(non_nest_mixed_sparsity)
+
+        opt = mat.handle.Option.NEW_NONZERO_ALLOCATION_ERR
+        opt2 = mat.handle.Option.UNUSED_NONZERO_LOCATION_ERR
+        mat.handle.setOption(opt, False)
+        mat.handle.setOption(opt2, False)
+        for m in mat:
+            m.handle.setOption(opt, False)
+            m.handle.setOption(opt2, False)
+        return mat
+
+    def test_mat_starts_assembled(self, backend, mat):
+        assert mat.assembly_state is op2.Mat.ASSEMBLED
+        for m in mat:
+            assert mat.assembly_state is op2.Mat.ASSEMBLED
+
+    def test_after_set_local_state_is_insert(self, backend, mat):
+        mat[0, 0].set_local_diagonal_entries([0])
+        mat._force_evaluation()
+        assert mat[0, 0].assembly_state is op2.Mat.INSERT_VALUES
+        if not mat.sparsity.nested:
+            assert mat.assembly_state is op2.Mat.INSERT_VALUES
+        assert mat[1, 1].assembly_state is op2.Mat.ASSEMBLED
+
+    def test_after_addto_state_is_add(self, backend, mat):
+        mat[0, 0].addto_values(0, 0, [1])
+        mat._force_evaluation()
+        assert mat[0, 0].assembly_state is op2.Mat.ADD_VALUES
+        if not mat.sparsity.nested:
+            assert mat.assembly_state is op2.Mat.ADD_VALUES
+        assert mat[1, 1].assembly_state is op2.Mat.ASSEMBLED
+
+    def test_matblock_assemble_runtimeerror(self, backend, mat):
+        if mat.sparsity.nested:
+            return
+        with pytest.raises(RuntimeError):
+            mat[0, 0].assemble()
+
+        with pytest.raises(RuntimeError):
+            mat[0, 0]._assemble()
+
+    def test_assembly_flushed_between_insert_and_add(self, backend, mat):
+        import types
+        flush_counter = [0]
+
+        def make_flush(old_flush):
+            def flush(self):
+                old_flush()
+                flush_counter[0] += 1
+            return flush
+
+        oflush = mat._flush_assembly
+        mat._flush_assembly = types.MethodType(make_flush(oflush), mat, type(mat))
+        if mat.sparsity.nested:
+            for m in mat:
+                oflush = m._flush_assembly
+                m._flush_assembly = types.MethodType(make_flush(oflush), m, type(m))
+
+        mat[0, 0].addto_values(0, 0, [1])
+        mat._force_evaluation()
+        assert flush_counter[0] == 0
+        mat[0, 0].set_values(1, 0, [2])
+        mat._force_evaluation()
+        assert flush_counter[0] == 1
+        mat.assemble()
+        mat._force_evaluation()
+        assert flush_counter[0] == 1
 
 
 class TestMixedMatrices:


### PR DESCRIPTION
Correctly calls Mat assembly with assembly type flush on petsc matrices when switching between adding and inserting values.

Switches the travis build to build PETSc with debugging enabled to try and catch these kind of issues.