### PR TITLE
Allow use to specifier arguments to linker

### DIFF
--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -789,6 +789,8 @@ class JITModule(base.JITModule):
             ldargs += blas['link']
             if blas['name'] == 'eigen':
                 extension = "cpp"
+        ldargs += self._kernel._ldargs
+
         if self._kernel._cpp:
             extension = "cpp"
         self._fun = compilation.load(code_to_compile,


### PR DESCRIPTION
When building a Kernel, the user might need to provide extra arguments
to the linker.  Pass ldargs through.