### PR TITLE
Fix assembly tracking for MatBlock

### DIFF
--- a/pyop2/petsc_base.py
+++ b/pyop2/petsc_base.py
@@ -397,17 +397,15 @@ class MatBlock(base.Mat):
         colis = cset.local_ises[j]
         self.handle = parent.handle.getLocalSubMatrix(isrow=rowis,
                                                       iscol=colis)
-        self._assembly_state = self._parent.assembly_state
 
     @property
     def assembly_state(self):
         # Track our assembly state only
-        return self._assembly_state
+        return self._parent.assembly_state
 
     @assembly_state.setter
     def assembly_state(self, state):
         # Need to update our state and our parent's
-        self._assembly_state = state
         self._parent.assembly_state = state
 
     def __getitem__(self, idx):
@@ -480,6 +478,9 @@ class MatBlock(base.Mat):
 
     def __repr__(self):
         return "MatBlock(%r, %r, %r)" % (self._parent, self._i, self._j)
+
+    def __str__(self):
+        return "Block[%s, %s] of %s" % (self._i, self._j, self._parent)
 
 
 class Mat(base.Mat, CopyOnWrite):

--- a/test/unit/test_matrices.py
+++ b/test/unit/test_matrices.py
@@ -840,7 +840,8 @@ class TestMatrixStateChanges:
         assert mat[0, 0].assembly_state is op2.Mat.INSERT_VALUES
         if not mat.sparsity.nested:
             assert mat.assembly_state is op2.Mat.INSERT_VALUES
-        assert mat[1, 1].assembly_state is op2.Mat.ASSEMBLED
+        if mat.sparsity.nested:
+            assert mat[1, 1].assembly_state is op2.Mat.ASSEMBLED
 
     def test_after_addto_state_is_add(self, backend, mat):
         mat[0, 0].addto_values(0, 0, [1])
@@ -848,7 +849,8 @@ class TestMatrixStateChanges:
         assert mat[0, 0].assembly_state is op2.Mat.ADD_VALUES
         if not mat.sparsity.nested:
             assert mat.assembly_state is op2.Mat.ADD_VALUES
-        assert mat[1, 1].assembly_state is op2.Mat.ASSEMBLED
+        if mat.sparsity.nested:
+            assert mat[1, 1].assembly_state is op2.Mat.ASSEMBLED
 
     def test_matblock_assemble_runtimeerror(self, backend, mat):
         if mat.sparsity.nested:


### PR DESCRIPTION
In the MatBlock case, the individual blocks should just track the
assembly state of the global operator.