### PR TITLE
MatBlock: Add test for, and fix, mixing insert and add

### DIFF
--- a/pyop2/petsc_base.py
+++ b/pyop2/petsc_base.py
@@ -415,7 +415,9 @@ class MatBlock(base.Mat):
         yield self
 
     def _flush_assembly(self):
-        self.handle.assemble(assembly=PETSc.Mat.AssemblyType.FLUSH)
+        # Need to flush for all blocks
+        for b in self._parent:
+            b.handle.assemble(assembly=PETSc.Mat.AssemblyType.FLUSH)
         self._parent._flush_assembly()
 
     def set_local_diagonal_entries(self, rows, diag_val=1.0, idx=None):

--- a/test/unit/test_matrices.py
+++ b/test/unit/test_matrices.py
@@ -861,6 +861,20 @@ class TestMatrixStateChanges:
         with pytest.raises(RuntimeError):
             mat[0, 0]._assemble()
 
+    def test_mixing_insert_and_add_works(self, backend, mat):
+        mat[0, 0].addto_values(0, 0, [1])
+        mat[1, 1].addto_values(1, 1, [3])
+        mat[1, 1].set_values(0, 0, [2])
+        mat[0, 0].set_values(1, 1, [4])
+        mat[1, 1].addto_values(0, 0, [3])
+        mat.assemble()
+
+        assert np.allclose(mat[0, 0].values, np.diag([1, 4, 0]))
+        assert np.allclose(mat[1, 1].values, np.diag([5, 3, 0, 0]))
+
+        assert np.allclose(mat[0, 1].values, 0)
+        assert np.allclose(mat[1, 0].values, 0)
+
     def test_assembly_flushed_between_insert_and_add(self, backend, mat):
         import types
         flush_counter = [0]


### PR DESCRIPTION
In the MatBlock case, because only track the parent assembly state, when
we flush assembly on a child we need to flush the state of all the
blocks (this is effectively does no computation in PETSc since MatBlocks
are not full-featured matrices, but it does keep PETSc's view of the
state in line with ours).