### PR TITLE
Better vecscatter

### DIFF
--- a/pyop2/petsc_base.py
+++ b/pyop2/petsc_base.py
@@ -261,7 +261,9 @@ class Dat(base.Dat):
             "Can't create Vec with type %s, must be %s" % (self.dtype, PETSc.ScalarType)
         acc = (lambda d: d.data_ro) if readonly else (lambda d: d.data)
         # Getting the Vec needs to ensure we've done all current computation.
-        self._force_evaluation()
+        # If we only want readonly access then there's no need to
+        # force the evaluation of reads from the Dat.
+        self._force_evaluation(read=True, write=not readonly)
         if not hasattr(self, '_vec'):
             # Can't duplicate layout_vec of dataset, because we then
             # carry around extra unnecessary data.


### PR DESCRIPTION
This moves creation of vec scatters to where they logically belong, the MixedDataSet.  This means we can share scatters amongst dats, significantly reducing memory load.  Additionally, DataSets get a layout_vec property that is a PETSc Vec.  This can be duplicated or referenced to avoid synchronisation when creating new Vecs.  In the MixedDat case, I do exactly this, in the Dat case, I cannot because we use vecCreateWithArray.  However, I use the layout vec to provide local and global sizes, which saves an allreduce.