### PR TITLE
Only include diagonal in sparsity if row and column dataset are the same

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3296,6 +3296,8 @@ class Sparsity(ObjectCached):
         self._nrows = self._rmaps[0].toset.size
         self._ncols = self._cmaps[0].toset.size
 
+        self._has_diagonal = self._rmaps[0].toset == self._cmaps[0].toset
+
         tmp = itertools.product([x.cdim for x in self._dsets[0]],
                                 [x.cdim for x in self._dsets[1]])
 

--- a/pyop2/petsc_base.py
+++ b/pyop2/petsc_base.py
@@ -376,6 +376,7 @@ class SparsityBlock(base.Sparsity):
         self._cmaps = tuple(m.split[j] for m in parent.cmaps)
         self._nrows = self._dsets[0].size
         self._ncols = self._dsets[1].size
+        self._has_diagonal = i == j and parent._has_diagonal
         self._parent = parent
         self._dims = tuple([tuple([parent.dims[i][j]])])
         self._blocks = [[self]]
@@ -565,7 +566,7 @@ class Mat(base.Mat, CopyOnWrite):
                     sparsity.fill_with_zeros(self[i, j].handle,
                                              self[i, j].sparsity.dims[0][0],
                                              self[i, j].sparsity.maps,
-                                             set_diag=(i == j))
+                                             set_diag=self[i, j].sparsity._has_diagonal)
 
         mat.assemble()
         mat.setOption(mat.Option.IGNORE_ZERO_ENTRIES, True)
@@ -630,7 +631,7 @@ class Mat(base.Mat, CopyOnWrite):
 
         # Put zeros in all the places we might eventually put a value.
         with timed_region("MatZeroInitial"):
-            sparsity.fill_with_zeros(mat, self.sparsity.dims[0][0], self.sparsity.maps)
+            sparsity.fill_with_zeros(mat, self.sparsity.dims[0][0], self.sparsity.maps, set_diag=self.sparsity._has_diagonal)
 
         # Now we've filled up our matrix, so the sparsity is
         # "complete", we can ignore subsequent zero entries.

--- a/pyop2/sparsity.pyx
+++ b/pyop2/sparsity.pyx
@@ -265,7 +265,7 @@ def build_sparsity(object sparsity, bint parallel, bool block=True):
                     # Preallocate set entries heuristically based on arity
                     cur_nrows = rset[r].size * rdim
                     rarity = rmap.arity
-                    alloc_diag = r == c
+                    alloc_diag = r == c and sparsity._has_diagonal
                     for i in range(cur_nrows):
                         diag[c][row_offset + i].reserve(6*rarity)
                         if alloc_diag and i < ncols:

--- a/test/unit/test_matrices.py
+++ b/test/unit/test_matrices.py
@@ -584,16 +584,18 @@ class TestSparsity:
             m = op2.Map(s, s, 1)
             op2.Sparsity((s, s), (m, m))
 
-    def test_sparsity_always_has_diagonal_space(self, backend):
-        # A sparsity should always have space for diagonal entries
+    def test_sparsity_has_diagonal_space(self, backend):
+        # A sparsity should have space for diagonal entries if rmap==cmap
         s = op2.Set(1)
         d = op2.Set(4)
-        m = op2.Map(s, d, 1, [2])
-        d2 = op2.Set(5)
-        m2 = op2.Map(s, d2, 2, [1, 4])
-        sparsity = op2.Sparsity((d, d2), (m, m2))
+        m = op2.Map(s, d, 2, [1, 3])
+        d2 = op2.Set(4)
+        m2 = op2.Map(s, d2, 3, [1, 2, 3])
+        sparsity = op2.Sparsity((d, d), (m, m))
+        sparsity2 = op2.Sparsity((d, d2), (m, m2))
 
-        assert all(sparsity.nnz == [1, 1, 3, 1])
+        assert all(sparsity.nnz == [1, 2, 1, 2])
+        assert all(sparsity2.nnz == [0, 3, 0, 3])
 
 
 class TestMatrices:


### PR DESCRIPTION
Currently entries are reserved for the diagonal in a sparsity regardless of whether the matrix is square or not. This leads to spurious nonzero entries in the PETSc matrices. This branch changes this to only reserve space for the diagonal when the row and column dataset are the same.

The main motivation for this is the performance of AMG preconditioners on the Schur complement of a mixed system. Take the case of the standard [[M, G], [C, 0]] saddlepoint system coming from du/dt+grad p=0 with div(u)=0. Although the extra nonzeros in the discretised gradient and continuity matrices G and C is relatively small, if you look at the 'selfp' fieldsplit preconditioner matrix for the Schur complement C M^-1 G the number of nonzeros is twice that what it needs to be. This leads to a dramatic performance degradation of the GAMG preconditioner (I've seen a factor of 10 slower for large systems) as the number of nonzeros at the coarser levels explodes. The performance of hypre+boomeramg is also improved by not including the diagonals in the G and C matrices (roughly twice, consistent with the n/o nonzeros).

More generally having a spurious diagonal for the non-square case may affect cache performance, as the column index of the diagonal will generally be wildly different than those of the other "local" column indices.

I presume the motivation for preallocating a diagonal in the *square* case is to ensure DirichletBCs can later be applied? Am I right in thinking this isn't necessary for the non-square case, as I'm not sure how DirichletBCs would work in that case? If this does need to be supported, can we make the allocation of a diagonal optional?