### PR TITLE
Temporary fix for Mat buffer size when flatten=False

### DIFF
--- a/pyop2/host.py
+++ b/pyop2/host.py
@@ -948,6 +948,10 @@ def wrapper_snippets(itspace, args,
             else:
                 _buf_size = [sum(_buf_size)]
                 _loop_size = _buf_size
+        else:
+            if not arg._flatten:
+                _dat_size = arg.data.dims[0][0]  # TODO: [0][0] ?
+                _buf_size = [e*d for e, d in zip(_buf_size, _dat_size)]
         _buf_decl[arg] = arg.c_buffer_decl(_buf_size, count, _buf_name[arg], is_facet=is_facet)
         _tmp_decl[arg] = arg.c_buffer_decl(_buf_size, count, _tmp_name[arg], is_facet=is_facet,
                                            init=False)


### PR DESCRIPTION
Fixes a bug that causes segmentation faults without `flatten=True`. FInAT does not use `flatten=True`.