### PR TITLE
Future imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_install:
        --allow-external petsc4py  --allow-unverified petsc4py \
        < requirements-git.txt"
   - pip install pulp
+  - pip install -U flake8 flake8-future-import
 install: "python setup.py develop"
 # command to run tests
 script:

--- a/pyop2/__init__.py
+++ b/pyop2/__init__.py
@@ -1,7 +1,7 @@
 """
 PyOP2 is a library for parallel computations on unstructured meshes.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 from pyop2.op2 import *  # noqa
 from pyop2.version import __version_info__  # noqa: just expose
 

--- a/pyop2/_version.py
+++ b/pyop2/_version.py
@@ -9,7 +9,7 @@
 # versioneer-0.16 (https://github.com/warner/python-versioneer)
 
 """Git implementation of _version.py."""
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 import errno
 import os
 import re

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2070,7 +2070,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
         ops = {operator.add: ast.Sum,
                operator.sub: ast.Sub,
                operator.mul: ast.Prod,
-               operator.div: ast.Div}
+               operator.truediv: ast.Div}
         ret = _make_object('Dat', self.dataset, None, self.dtype)
         name = "binop_%s" % op.__name__
         if np.isscalar(other):
@@ -2110,7 +2110,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
         ops = {operator.iadd: ast.Incr,
                operator.isub: ast.Decr,
                operator.imul: ast.IMul,
-               operator.idiv: ast.IDiv}
+               operator.itruediv: ast.IDiv}
         name = "iop_%s" % op.__name__
         if np.isscalar(other):
             other = _make_object('Global', 1, data=other)
@@ -2226,9 +2226,11 @@ class Dat(DataCarrier, _EmptyDataMixin):
         self.__rmul__(other) <==> other * self."""
         return self.__mul__(other)
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         """Pointwise division or scaling of fields."""
-        return self._op(other, operator.div)
+        return self._op(other, operator.truediv)
+
+    __div__ = __truediv__  # Python 2 compatibility
 
     def __iadd__(self, other):
         """Pointwise addition of fields."""
@@ -2242,9 +2244,11 @@ class Dat(DataCarrier, _EmptyDataMixin):
         """Pointwise multiplication or scaling of fields."""
         return self._iop(other, operator.imul)
 
-    def __idiv__(self, other):
+    def __itruediv__(self, other):
         """Pointwise division or scaling of fields."""
-        return self._iop(other, operator.idiv)
+        return self._iop(other, operator.itruediv)
+
+    __idiv__ = __itruediv__  # Python 2 compatibility
 
     @collective
     def halo_exchange_begin(self, reverse=False):

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -35,7 +35,7 @@
 information which is backend independent. Individual runtime backends should
 subclass these as required to implement backend-specific features.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 from contextlib import contextmanager
 import itertools
@@ -57,6 +57,7 @@ from pyop2.version import __version__ as version
 from coffee.base import Node, FlatBlock
 from coffee.visitors import FindInstances, EstimateFlops
 from coffee import base as ast
+from functools import reduce
 
 
 def _make_object(name, *args, **kwargs):
@@ -3287,7 +3288,7 @@ class Sparsity(ObjectCached):
             dims = [[None for _ in range(self.shape[1])] for _ in range(self.shape[0])]
             for r in range(self.shape[0]):
                 for c in range(self.shape[1]):
-                    dims[r][c] = tmp.next()
+                    dims[r][c] = next(tmp)
 
             self._dims = tuple(tuple(d) for d in dims)
 

--- a/pyop2/caching.py
+++ b/pyop2/caching.py
@@ -33,7 +33,7 @@
 
 """Provides common base classes for cached objects."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 from pyop2.utils import cached_property
 
@@ -50,22 +50,22 @@ def report_cache(typ):
     typs = defaultdict(lambda: 0)
     n = 0
     for x in get_objects():
-        if isinstance(x, (typ, )):
+        if isinstance(x, typ):
             typs[type(x)] += 1
             n += 1
     if n == 0:
-        print "\nNo %s objects in caches" % typ.__name__
+        print("\nNo %s objects in caches" % typ.__name__)
         return
-    print "\n%d %s objects in caches" % (n, typ.__name__)
-    print "Object breakdown"
-    print "================"
+    print("\n%d %s objects in caches" % (n, typ.__name__))
+    print("Object breakdown")
+    print("================")
     for k, v in typs.iteritems():
         mod = getmodule(k)
         if mod is not None:
             name = "%s.%s" % (mod.__name__, k.__name__)
         else:
             name = k.__name__
-        print '%s: %d' % (name, v)
+        print('%s: %d' % (name, v))
 
 
 class ObjectCached(object):

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -31,7 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
+
 import os
 import subprocess
 import sys
@@ -346,7 +347,7 @@ def clear_cache(prompt=False):
     nfiles = len(files)
 
     if nfiles == 0:
-        print "No cached libraries to remove"
+        print("No cached libraries to remove")
         return
 
     remove = True
@@ -355,14 +356,14 @@ def clear_cache(prompt=False):
         user = raw_input("Remove %d cached libraries from %s? [Y/n]: " % (nfiles, cachedir))
 
         while user.lower() not in ['', 'y', 'n']:
-            print "Please answer y or n."
+            print("Please answer y or n.")
             user = raw_input("Remove %d cached libraries from %s? [Y/n]: " % (nfiles, cachedir))
 
         if user.lower() == 'n':
             remove = False
 
     if remove:
-        print "Removing %d cached libraries from %s" % (nfiles, cachedir)
+        print("Removing %d cached libraries from %s" % (nfiles, cachedir))
         [os.remove(f) for f in files]
     else:
-        print "Not removing cached libraries"
+        print("Not removing cached libraries")

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -33,7 +33,7 @@
 
 """PyOP2 global configuration."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 import os
 from tempfile import gettempdir
 

--- a/pyop2/exceptions.py
+++ b/pyop2/exceptions.py
@@ -32,7 +32,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """OP2 exception types"""
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 
 class DataTypeError(TypeError):

--- a/pyop2/fusion/__init__.py
+++ b/pyop2/fusion/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import, print_function, division

--- a/pyop2/fusion/extended.py
+++ b/pyop2/fusion/extended.py
@@ -34,6 +34,8 @@
 """Classes for fusing parallel loops and for executing fused parallel loops,
 derived from ``base.py``."""
 
+from __future__ import absolute_import, print_function, division
+
 import sys
 import ctypes
 from copy import deepcopy as dcopy

--- a/pyop2/fusion/filters.py
+++ b/pyop2/fusion/filters.py
@@ -33,6 +33,8 @@
 
 """Classes for handling duplicate arguments in parallel loops and kernels."""
 
+from __future__ import absolute_import, print_function, division
+
 from collections import OrderedDict
 
 from pyop2.base import READ, RW, WRITE

--- a/pyop2/fusion/interface.py
+++ b/pyop2/fusion/interface.py
@@ -34,6 +34,8 @@
 """Interface for loop fusion. Some functions will be called from within PyOP2
 itself, whereas others directly from application code."""
 
+from __future__ import absolute_import, print_function, division
+
 import os
 from contextlib import contextmanager
 

--- a/pyop2/fusion/scheduler.py
+++ b/pyop2/fusion/scheduler.py
@@ -37,15 +37,17 @@ and two scheduling functions S1 and S2, one can compute L' = S2(S1(L)), with S1(
 returning, for example, [L0, L1',L3] and L' = S2([L0, L1', L3]) = [L0, L1''].
 Different scheduling functions may implement different loop fusion strategies."""
 
+from __future__ import absolute_import, print_function, division
+
 from copy import deepcopy as dcopy, copy as scopy
 import numpy as np
 
 from pyop2.base import Dat, RW, _make_object
 from pyop2.utils import flatten
 
-from extended import FusionArg, FusionParLoop, \
+from .extended import FusionArg, FusionParLoop, \
     TilingArg, TilingIterationSpace, TilingParLoop
-from filters import Filter, WeakFilter
+from .filters import Filter, WeakFilter
 
 
 __all__ = ['Schedule', 'PlainSchedule', 'FusionSchedule',

--- a/pyop2/fusion/transformer.py
+++ b/pyop2/fusion/transformer.py
@@ -847,8 +847,8 @@ def estimate_data_reuse(filename, loop_chain):
             tot_flops += flops
         f.write('** Summary: %d KBytes moved, %d Megaflops performed\n' %
                 (tot_footprint, tot_flops))
-        probSeed = 0 if MPI.COMM_WORLD.size > 1 else len(loop_chain) / 2
-        probNtiles = loop_chain[probSeed].it_space.exec_size / tile_size or 1
+        probSeed = 0 if MPI.COMM_WORLD.size > 1 else len(loop_chain) // 2
+        probNtiles = loop_chain[probSeed].it_space.exec_size // tile_size or 1
         f.write('** KB/tile: %d' % (tot_footprint/probNtiles))
         f.write('  (Estimated: %d tiles)\n' % probNtiles)
         f.write('-' * 68 + '\n')
@@ -880,7 +880,7 @@ def estimate_data_reuse(filename, loop_chain):
             ideal_reuse += (size/1000)*len(positions[1:])
 
         out = '** Ideal reuse (i.e., no tile growth): %d / %d KBytes (%f %%)\n' % \
-            (ideal_reuse, tot_footprint, float(ideal_reuse)*100/tot_footprint)
+            (ideal_reuse, tot_footprint, ideal_reuse*100/tot_footprint)
         f.write(out)
         f.write('-' * 125 + '\n')
         s.write(out)

--- a/pyop2/fusion/transformer.py
+++ b/pyop2/fusion/transformer.py
@@ -33,6 +33,8 @@
 
 """Core loop fusion mechanisms."""
 
+from __future__ import absolute_import, print_function, division
+
 import sys
 import os
 from collections import OrderedDict, namedtuple
@@ -47,10 +49,10 @@ from pyop2.utils import flatten, as_tuple, tuplify
 from pyop2.logger import warning
 from pyop2 import compilation
 
-from extended import lazy_trace_name, Kernel
-from filters import Filter, WeakFilter
-from interface import slope
-from scheduler import *
+from .extended import lazy_trace_name, Kernel
+from .filters import Filter, WeakFilter
+from .interface import slope
+from .scheduler import *
 
 import coffee
 from coffee import base as ast

--- a/pyop2/logger.py
+++ b/pyop2/logger.py
@@ -32,7 +32,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """The PyOP2 logger, based on the Python standard library logging module."""
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 from contextlib import contextmanager
 import logging

--- a/pyop2/mpi.py
+++ b/pyop2/mpi.py
@@ -33,7 +33,7 @@
 
 """PyOP2 MPI communicator."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 from petsc4py import PETSc
 from mpi4py import MPI  # noqa
 import atexit

--- a/pyop2/op2.py
+++ b/pyop2/op2.py
@@ -33,7 +33,7 @@
 
 """The PyOP2 API specification."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 import atexit
 
 from pyop2.configuration import configuration
@@ -109,7 +109,7 @@ def exit():
     """Exit OP2 and clean up"""
     if configuration['print_cache_size'] and COMM_WORLD.rank == 0:
         from caching import report_cache, Cached, ObjectCached
-        print '**** PyOP2 cache sizes at exit ****'
+        print('**** PyOP2 cache sizes at exit ****')
         report_cache(typ=ObjectCached)
         report_cache(typ=Cached)
     configuration.reset()

--- a/pyop2/petsc_base.py
+++ b/pyop2/petsc_base.py
@@ -608,7 +608,7 @@ class MatBlock(base.Mat):
 
     @property
     def nbytes(self):
-        return self._parent.nbytes / (np.prod(self.sparsity.shape))
+        return self._parent.nbytes // (np.prod(self.sparsity.shape))
 
     def __repr__(self):
         return "MatBlock(%r, %r, %r)" % (self._parent, self._i, self._j)

--- a/pyop2/petsc_base.py
+++ b/pyop2/petsc_base.py
@@ -31,7 +31,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 from contextlib import contextmanager
 from petsc4py import PETSc
 from functools import partial

--- a/pyop2/profiling.py
+++ b/pyop2/profiling.py
@@ -31,7 +31,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 from petsc4py import PETSc
 from decorator import decorator
@@ -56,7 +56,7 @@ class timed_function(object):
     def __call__(self, f):
         def wrapper(f, *args, **kwargs):
             if self.name is None:
-                self.name = f.func_name
+                self.name = f.__name__
             with timed_region(self.name):
                 return f(*args, **kwargs)
         return decorator(wrapper, f)

--- a/pyop2/pyparloop.py
+++ b/pyop2/pyparloop.py
@@ -74,7 +74,7 @@ Example usage::
   #  [ 3.  0.]]
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 import numpy as np
 from pyop2 import base
 

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -1065,7 +1065,7 @@ def wrapper_snippets(itspace, args,
             # Only adjust size if not flattening (in which case the buffer is extents*dat.dim)
             if not arg._flatten:
                 _buf_size = [sum([e*d for e, d in zip(_buf_size, _dat_size)])]
-                _loop_size = [_buf_size[i]/_dat_size[i] for i in range(len(_buf_size))]
+                _loop_size = [_buf_size[i]//_dat_size[i] for i in range(len(_buf_size))]
             else:
                 _buf_size = [sum(_buf_size)]
                 _loop_size = _buf_size
@@ -1113,7 +1113,7 @@ def wrapper_snippets(itspace, args,
                 _buf_offset, _buf_offset_decl = '', ''
             elif arg._is_dat:
                 dim = arg.data.split[i].cdim
-                loop_size = shape[0]*mult/dim
+                loop_size = shape[0]*mult//dim
                 _itspace_loops, _itspace_loop_close = itspace_loop(0, loop_size), '}'
                 _buf_offset_name = 'offset_%d[%s]' % (count, '%s')
                 _buf_offset_decl = 'int %s' % _buf_offset_name % loop_size

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -32,7 +32,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """OP2 sequential backend."""
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, division
 
 import os
 import ctypes

--- a/pyop2/utils.py
+++ b/pyop2/utils.py
@@ -33,7 +33,7 @@
 
 """Common utility classes/functions."""
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, print_function, division
 
 import os
 import sys
@@ -120,11 +120,11 @@ class validate_base:
     def __call__(self, f):
         def wrapper(f, *args, **kwargs):
             if configuration["type_check"]:
-                self.nargs = f.func_code.co_argcount
-                self.defaults = f.func_defaults or ()
-                self.varnames = f.func_code.co_varnames
-                self.file = f.func_code.co_filename
-                self.line = f.func_code.co_firstlineno + 1
+                self.nargs = f.__code__.co_argcount
+                self.defaults = f.__defaults__ or ()
+                self.varnames = f.__code__.co_varnames
+                self.file = f.__code__.co_filename
+                self.line = f.__code__.co_firstlineno + 1
                 self.check_args(args, kwargs)
             return f(*args, **kwargs)
         return decorator(wrapper, f)
@@ -306,14 +306,14 @@ def trim(docstring):
     # and split into a list of lines:
     lines = docstring.expandtabs().splitlines()
     # Determine minimum indentation (first line doesn't count):
-    indent = sys.maxint
+    indent = sys.maxsize
     for line in lines[1:]:
         stripped = line.lstrip()
         if stripped:
             indent = min(indent, len(line) - len(stripped))
     # Remove indentation (first line is special):
     trimmed = [lines[0].strip()]
-    if indent < sys.maxint:
+    if indent < sys.maxsize:
         for line in lines[1:]:
             trimmed.append(line[indent:].rstrip())
     # Strip off trailing and leading blank lines:

--- a/pyop2/version.py
+++ b/pyop2/version.py
@@ -1,2 +1,4 @@
+from __future__ import absolute_import, print_function, division
+
 __version_info__ = (0, 12, 0)
 __version__ = '.'.join(map(str, __version_info__))

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,5 +12,9 @@ tag_prefix = v
 parentdir_prefix = pyop2-
 
 [flake8]
-ignore = E501,F403,F405,E226,E402,E721,E731,W503,F999
-exclude = .git,__pycache__,build,.tox,dist,yacctab.py,lextab.py,doc/sphinx/source/conf.py,_version.py
+ignore =
+    E501,F403,F405,E226,E402,E721,E731,W503,F999,
+    FI14,FI54,
+    FI50,FI51,FI53
+exclude = .git,__pycache__,build,dist,doc/sphinx/source/conf.py,doc/sphinx/server.py,demo
+min-version = 2.7

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
 try:
     from setuptools import setup, Extension
 except ImportError:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,6 +33,8 @@
 
 """Global test configuration."""
 
+from __future__ import absolute_import, print_function, division
+
 import os
 import pytest
 from pyop2 import op2

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -34,6 +34,7 @@
 """
 User API Unit Tests
 """
+from __future__ import absolute_import, print_function, division
 
 import pytest
 import numpy as np

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -1227,7 +1227,7 @@ class TestSparsityAPI:
         "Iterating a Sparsity should yield the block by row."
         cols = ms.shape[1]
         for i, block in enumerate(ms):
-            assert block == ms[i / cols, i % cols]
+            assert block == ms[i // cols, i % cols]
 
     def test_sparsity_mmap_getitem(self, ms):
         """Sparsity block i, j should be defined on the corresponding row and

--- a/test/unit/test_caching.py
+++ b/test/unit/test_caching.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy
 import random

--- a/test/unit/test_configuration.py
+++ b/test/unit/test_configuration.py
@@ -33,6 +33,8 @@
 
 """Configuration unit tests."""
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 from pyop2.configuration import Configuration
 from pyop2.exceptions import ConfigurationError

--- a/test/unit/test_dats.py
+++ b/test/unit/test_dats.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy as np
 

--- a/test/unit/test_direct_loop.py
+++ b/test/unit/test_direct_loop.py
@@ -44,8 +44,8 @@ nelems = 4096
 
 @pytest.fixture(params=[(nelems, nelems, nelems, nelems),
                         (0, nelems, nelems, nelems),
-                        (nelems / 2, nelems, nelems, nelems),
-                        (0, nelems/2, nelems, nelems)])
+                        (nelems // 2, nelems, nelems, nelems),
+                        (0, nelems//2, nelems, nelems)])
 def elems(request):
     return op2.Set(request.param, "elems")
 
@@ -110,9 +110,9 @@ class TestDirectLoop:
         op2.par_loop(op2.Kernel(kernel_rw, "kernel_rw"),
                      elems, x(op2.RW))
         _nelems = elems.size
-        assert sum(x.data_ro) == _nelems * (_nelems + 1) / 2
+        assert sum(x.data_ro) == _nelems * (_nelems + 1) // 2
         if _nelems == nelems:
-            assert sum(x.data_ro_with_halos) == nelems * (nelems + 1) / 2
+            assert sum(x.data_ro_with_halos) == nelems * (nelems + 1) // 2
 
     def test_global_inc(self, elems, x, g):
         """Increment each value of a Dat by one and a Global at the same time."""
@@ -122,7 +122,7 @@ class TestDirectLoop:
         op2.par_loop(op2.Kernel(kernel_global_inc, "kernel_global_inc"),
                      elems, x(op2.RW), g(op2.INC))
         _nelems = elems.size
-        assert g.data[0] == _nelems * (_nelems + 1) / 2
+        assert g.data[0] == _nelems * (_nelems + 1) // 2
 
     def test_global_inc_init_not_zero(self, elems, g):
         """Increment a global initialized with a non-zero value."""
@@ -190,7 +190,7 @@ class TestDirectLoop:
         op2.par_loop(op2.Kernel(kernel_global_read, "kernel_global_read"),
                      elems, x(op2.RW), h(op2.READ))
         _nelems = elems.size
-        assert sum(x.data_ro) == _nelems * (_nelems + 1) / 2
+        assert sum(x.data_ro) == _nelems * (_nelems + 1) // 2
 
     def test_2d_dat(self, elems, y):
         """Set both components of a vector-valued Dat to a scalar value."""

--- a/test/unit/test_direct_loop.py
+++ b/test/unit/test_direct_loop.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy as np
 

--- a/test/unit/test_extrusion.py
+++ b/test/unit/test_extrusion.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy
 import random

--- a/test/unit/test_extrusion.py
+++ b/test/unit/test_extrusion.py
@@ -192,7 +192,7 @@ def dat_coords(dnode_set2):
     count = 0
     for k in range(0, nums[0]):
         coords_dat[count:count + layers * dofs[0][0]] = numpy.tile(
-            [(k / 2), k % 2], layers)
+            [(k // 2), k % 2], layers)
         count += layers * dofs[0][0]
     return op2.Dat(dnode_set2, coords_dat, numpy.float64, "coords")
 
@@ -362,7 +362,7 @@ void comp_vol(double A[1], double *x[], double *y[])
                      dat_coords(op2.READ, coords_map),
                      dat_field(op2.READ, field_map))
 
-        assert int(g.data[0]) == int((layers - 1) * 0.1 * (nelems / 2))
+        assert int(g.data[0]) == int((layers - 1) * 0.1 * (nelems // 2))
 
     def test_extruded_nbytes(self, dat_field):
         """Nbytes computes the number of bytes occupied by an extruded Dat."""

--- a/test/unit/test_fusion.py
+++ b/test/unit/test_fusion.py
@@ -402,8 +402,8 @@ class TestTiling:
 
     @pytest.mark.parametrize(('nu', 'ts'),
                              [(0, 1),
-                              (1, 1), (1, nelems/10), (1, nelems),
-                              (2, 1), (2, nelems/10), (2, nelems)])
+                              (1, 1), (1, nelems//10), (1, nelems),
+                              (2, 1), (2, nelems//10), (2, nelems)])
     def test_simple_tiling(self, ker_init, ker_reduce_ind_read, ker_write,
                            ker_write2d, iterset, indset, iterset2indset,
                            ix2, x, y, z, skip_greedy, nu, ts):
@@ -443,7 +443,7 @@ class TestTiling:
             op2.par_loop(op2.Kernel(ker_write, "ker_write"), iterset, x(op2.WRITE))
             op2.par_loop(op2.Kernel(ker_write2d, "ker_write2d"), indset, ix2(op2.WRITE))
             with loop_chain("tiling_war", mode='tile',
-                            tile_size=nelems/10, num_unroll=1, seed_loop=sl):
+                            tile_size=nelems//10, num_unroll=1, seed_loop=sl):
                 op2.par_loop(op2.Kernel(ker_ind_reduce, "ker_ind_reduce"),
                              indset, ix2(op2.INC), x(op2.READ, indset2iterset))
                 op2.par_loop(op2.Kernel(ker_reduce_ind_read, "ker_reduce_ind_read"),
@@ -454,7 +454,7 @@ class TestTiling:
 
     @pytest.mark.parametrize(('nu', 'ts', 'fs', 'sl'),
                              [(0, 1, (0, 5, 1), 0),
-                              (1, nelems/10, (0, 5, 1), 0)])
+                              (1, nelems//10, (0, 5, 1), 0)])
     def test_advanced_tiling(self, ker_init, ker_reduce_ind_read, ker_ind_reduce,
                              ker_write, ker_write2d, ker_inc, iterset, indset,
                              iterset2indset, indset2iterset, ix2, y, z, skip_greedy,
@@ -497,7 +497,7 @@ class TestTiling:
             op2.par_loop(op2.Kernel(ker_write, "ker_write"), iterset, y(op2.WRITE))
             op2.par_loop(op2.Kernel(ker_write, "ker_write"), bigiterset, bigx(op2.WRITE))
             op2.par_loop(op2.Kernel(ker_write, "ker_write"), indset, ix(op2.WRITE))
-            with loop_chain("tiling_acyclic_raw", mode='tile', tile_size=nelems/10,
+            with loop_chain("tiling_acyclic_raw", mode='tile', tile_size=nelems//10,
                             num_unroll=1, seed_loop=sl, ignore_war=True):
                 op2.par_loop(op2.Kernel(ker_ind_inc, 'ker_ind_inc'), bigiterset,
                              x(op2.INC, bigiterset2iterset), bigx(op2.READ))

--- a/test/unit/test_fusion.py
+++ b/test/unit/test_fusion.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy as np
 import random

--- a/test/unit/test_global_reduction.py
+++ b/test/unit/test_global_reduction.py
@@ -50,7 +50,7 @@ class TestGlobalReductions:
 
     @pytest.fixture(scope='module', params=[(nelems, nelems, nelems, nelems),
                                             (0, nelems, nelems, nelems),
-                                            (nelems / 2, nelems, nelems, nelems)])
+                                            (nelems // 2, nelems, nelems, nelems)])
     def set(cls, request):
         return op2.Set(request.param, 'set')
 

--- a/test/unit/test_global_reduction.py
+++ b/test/unit/test_global_reduction.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy
 from numpy.testing import assert_allclose

--- a/test/unit/test_hdf5.py
+++ b/test/unit/test_hdf5.py
@@ -35,6 +35,8 @@
 HDF5 API Unit Tests
 """
 
+from __future__ import absolute_import, print_function, division
+
 import numpy as np
 import pytest
 

--- a/test/unit/test_indirect_loop.py
+++ b/test/unit/test_indirect_loop.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy as np
 import random

--- a/test/unit/test_indirect_loop.py
+++ b/test/unit/test_indirect_loop.py
@@ -48,7 +48,7 @@ nelems = 4096
 
 @pytest.fixture(params=[(nelems, nelems, nelems, nelems),
                         (0, nelems, nelems, nelems),
-                        (nelems / 2, nelems, nelems, nelems)])
+                        (nelems // 2, nelems, nelems, nelems)])
 @pytest.fixture
 def iterset(request):
     return op2.Set(request.param, "iterset")
@@ -155,7 +155,7 @@ class TestIndirectLoop:
 
         op2.par_loop(op2.Kernel(kernel_rw, "kernel_rw"),
                      iterset, x(op2.RW, iterset2indset[0]))
-        assert sum(x.data) == nelems * (nelems + 1) / 2
+        assert sum(x.data) == nelems * (nelems + 1) // 2
 
     def test_indirect_inc(self, iterset, unitset, iterset2unitset):
         """Sum into a scalar Dat with op2.INC."""
@@ -175,7 +175,7 @@ class TestIndirectLoop:
                      iterset,
                      x(op2.RW, iterset2indset[0]),
                      g(op2.READ))
-        assert sum(x.data) == sum(map(lambda v: v / 2, range(nelems)))
+        assert sum(x.data) == sum(map(lambda v: v // 2, range(nelems)))
 
     def test_global_inc(self, iterset, x, iterset2indset):
         """Increment each value of a Dat by one and a Global at the same time."""
@@ -190,8 +190,8 @@ class TestIndirectLoop:
             op2.Kernel(kernel_global_inc, "kernel_global_inc"), iterset,
             x(op2.RW, iterset2indset[0]),
             g(op2.INC))
-        assert sum(x.data) == nelems * (nelems + 1) / 2
-        assert g.data[0] == nelems * (nelems + 1) / 2
+        assert sum(x.data) == nelems * (nelems + 1) // 2
+        assert g.data[0] == nelems * (nelems + 1) // 2
 
     def test_2d_dat(self, iterset, iterset2indset, x2):
         """Set both components of a vector-valued Dat to a scalar value."""

--- a/test/unit/test_iteration_space_dats.py
+++ b/test/unit/test_iteration_space_dats.py
@@ -45,7 +45,7 @@ def _seed():
     return 0.02041724
 
 nnodes = 4096
-nele = nnodes / 2
+nele = nnodes // 2
 
 
 @pytest.fixture(scope='module')

--- a/test/unit/test_iteration_space_dats.py
+++ b/test/unit/test_iteration_space_dats.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy
 

--- a/test/unit/test_laziness.py
+++ b/test/unit/test_laziness.py
@@ -35,6 +35,8 @@
 Lazy evaluation unit tests.
 """
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy
 

--- a/test/unit/test_linalg.py
+++ b/test/unit/test_linalg.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy as np
 

--- a/test/unit/test_matrices.py
+++ b/test/unit/test_matrices.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose

--- a/test/unit/test_petsc.py
+++ b/test/unit/test_petsc.py
@@ -35,6 +35,8 @@
 PETSc specific unit tests
 """
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy as np
 

--- a/test/unit/test_pyparloop.py
+++ b/test/unit/test_pyparloop.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy as np
 

--- a/test/unit/test_subset.py
+++ b/test/unit/test_subset.py
@@ -45,7 +45,7 @@ nelems = 32
 
 @pytest.fixture(params=[(nelems, nelems, nelems, nelems),
                         (0, nelems, nelems, nelems),
-                        (nelems / 2, nelems, nelems, nelems)])
+                        (nelems // 2, nelems, nelems, nelems)])
 def iterset(request):
     return op2.Set(request.param, "iterset")
 
@@ -107,7 +107,7 @@ class TestSubSet:
     def test_direct_loop_sub_subset(self, iterset):
         indices = np.arange(0, nelems, 2, dtype=np.int)
         ss = op2.Subset(iterset, indices)
-        indices = np.arange(0, nelems/2, 2, dtype=np.int)
+        indices = np.arange(0, nelems//2, 2, dtype=np.int)
         sss = op2.Subset(ss, indices)
 
         d = op2.Dat(iterset ** 1, data=None, dtype=np.uint32)
@@ -124,7 +124,7 @@ class TestSubSet:
     def test_direct_loop_sub_subset_with_indexing(self, iterset):
         indices = np.arange(0, nelems, 2, dtype=np.int)
         ss = iterset(indices)
-        indices = np.arange(0, nelems/2, 2, dtype=np.int)
+        indices = np.arange(0, nelems//2, 2, dtype=np.int)
         sss = ss(indices)
 
         d = op2.Dat(iterset ** 1, data=None, dtype=np.uint32)
@@ -150,7 +150,7 @@ class TestSubSet:
         k = op2.Kernel("void inc(unsigned int* v) { *v += 1;}", "inc")
         op2.par_loop(k, ss, d(op2.INC, map[0]))
 
-        assert d.data[0] == nelems / 2
+        assert d.data[0] == nelems // 2
 
     def test_indirect_loop_empty(self, iterset):
         """Test a indirect ParLoop on an empty"""
@@ -175,7 +175,7 @@ class TestSubSet:
         map = op2.Map(iterset, indset, 1, [(1 if i % 2 else 0) for i in range(nelems)])
 
         values = [2976579765] * nelems
-        values[::2] = [i/2 for i in range(nelems)][::2]
+        values[::2] = [i//2 for i in range(nelems)][::2]
         dat1 = op2.Dat(iterset ** 1, data=values, dtype=np.uint32)
         dat2 = op2.Dat(indset ** 1, data=None, dtype=np.uint32)
 

--- a/test/unit/test_subset.py
+++ b/test/unit/test_subset.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy as np
 

--- a/test/unit/test_vector_map.py
+++ b/test/unit/test_vector_map.py
@@ -43,7 +43,7 @@ def _seed():
     return 0.02041724
 
 nnodes = 4096
-nele = nnodes / 2
+nele = nnodes // 2
 
 
 @pytest.fixture(scope='module')

--- a/test/unit/test_vector_map.py
+++ b/test/unit/test_vector_map.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, print_function, division
+
 import pytest
 import numpy
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -348,7 +348,7 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function, division
 try:
     import configparser
 except ImportError:


### PR DESCRIPTION
- Adds `from __future__ import absolute_import, print_function, division` to all files.
- Enforces with CI that these future imports are always present.
- Fixes a few relative imports.
- Updates print statements to print functions.
- Updates to Python 3 division.