### PR TITLE
Allow passing layer argument to kernel

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -4040,6 +4040,14 @@ class ParLoop(LazyComputation):
         self._kernel = kernel
         self._is_layered = iterset._extruded
         self._iteration_region = kwargs.get("iterate", None)
+        self._pass_layer_arg = kwargs.get("pass_layer_arg", False)
+
+        if self._pass_layer_arg:
+            if self.is_direct:
+                raise ValueError("Can't request layer arg for direct iteration")
+            if not self._is_layered:
+                raise ValueError("Can't request layer arg for non-extruded iteration")
+
         # Are we only computing over owned set entities?
         self._only_local = isinstance(iterset, LocalSet)
 
@@ -4388,6 +4396,10 @@ def par_loop(kernel, it_space, *args, **kwargs):
               - ``ON_INTERIOR_FACETS`` iterate over all the layers
                  except the top layer, accessing data two adjacent (in
                  the extruded direction) cells at a time.
+
+    :kwarg pass_layer_arg: Should the wrapper pass the current layer
+        into the kernel (as an ``int``). Only makes sense for
+        indirect extruded iteration.
 
     .. warning ::
         It is the caller's responsibility that the number and type of all

--- a/test/unit/test_extrusion.py
+++ b/test/unit/test_extrusion.py
@@ -377,6 +377,25 @@ void comp_vol(double A[1], double *x[], double *y[])
                      dat.dataset.set, dat(op2.INC))
         assert numpy.allclose(dat.data[:], 1.0)
 
+    def test_extruded_layer_arg(self, elements, dat_coords,
+                                dat_field, coords_map, field_map,
+                                dat_f):
+        """Tests that the layer argument is being passed when prompted
+        to in the parloop."""
+
+        kernel_blah = """void kernel_blah(double* x[], int layer_arg){
+                                                 x[0][0] = layer_arg;
+                                              }\n"""
+
+        op2.par_loop(op2.Kernel(kernel_blah, "kernel_blah"),
+                     elements, dat_f(op2.WRITE, field_map),
+                     pass_layer_arg=True)
+        end = layers - 1
+        start = 0
+        ref = np.array(range(start, end))
+        assert [dat_f.data[10*n:10*(n+1)] == ref
+                for n in range(len(dat_f.data) + 1)]
+
     def test_write_data_field(self, elements, dat_coords, dat_field, coords_map, field_map, dat_f):
         kernel_wo = "void kernel_wo(double* x[]) { x[0][0] = 42.0; }\n"
 

--- a/test/unit/test_extrusion.py
+++ b/test/unit/test_extrusion.py
@@ -377,9 +377,7 @@ void comp_vol(double A[1], double *x[], double *y[])
                      dat.dataset.set, dat(op2.INC))
         assert numpy.allclose(dat.data[:], 1.0)
 
-    def test_extruded_layer_arg(self, elements, dat_coords,
-                                dat_field, coords_map, field_map,
-                                dat_f):
+    def test_extruded_layer_arg(self, elements, field_map, dat_f):
         """Tests that the layer argument is being passed when prompted
         to in the parloop."""
 
@@ -392,8 +390,8 @@ void comp_vol(double A[1], double *x[], double *y[])
                      pass_layer_arg=True)
         end = layers - 1
         start = 0
-        ref = np.array(range(start, end))
-        assert [dat_f.data[10*n:10*(n+1)] == ref
+        ref = np.arange(start, end)
+        assert [dat_f.data[end*n:end*(n+1)] == ref
                 for n in range(len(dat_f.data) + 1)]
 
     def test_write_data_field(self, elements, dat_coords, dat_field, coords_map, field_map, dat_f):


### PR DESCRIPTION
This PR does exactly what the title says: it allows for the layer argument (during an extrusion iteration) to be passed to the kernel in the wrapper.

The parameter is defaulted to `False` and should not affect any greater-Firedrake work unless the keyword argument `pass_layer_arg=True` is passed to the parloop. Slate will require this kwarg when handling extruded facet integrals.