### PR TITLE
Variable layers

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2886,7 +2886,7 @@ class Map(object):
         """Return any implicit (extruded "top" or "bottom") bcs to
         apply to this :class:`Map`. Normally empty except in the case of
         some :class:`DecoratedMap`\s."""
-        return frozenset([])
+        return ()
 
     @cached_property
     def vector_index(self):
@@ -3040,7 +3040,7 @@ class DecoratedMap(Map, ObjectCached):
         if implicit_bcs is None:
             implicit_bcs = []
         implicit_bcs = as_tuple(implicit_bcs)
-        self.implicit_bcs = frozenset(implicit_bcs)
+        self.implicit_bcs = tuple(sorted(implicit_bcs))
         self.vector_index = vector_index
         self._initialized = True
 

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -38,6 +38,7 @@ subclass these as required to implement backend-specific features.
 import abc
 
 from contextlib import contextmanager
+from collections import namedtuple
 import itertools
 import numpy as np
 import ctypes
@@ -46,7 +47,7 @@ import operator
 import types
 from hashlib import md5
 
-from pyop2.datatypes import IntType, as_cstr
+from pyop2.datatypes import IntType, as_cstr, _EntityMask, _MapMask
 from pyop2.configuration import configuration
 from pyop2.caching import Cached, ObjectCached
 from pyop2.exceptions import *
@@ -833,6 +834,22 @@ class ExtrudedSet(Set):
     def __repr__(self):
         return "ExtrudedSet(%r, %r)" % (self._parent, self._layers)
 
+    class EntityMask(namedtuple("_EntityMask_", ["section", "bottom", "top"])):
+        """Mask bits on each set entity indicating which topological
+        entities in the closure of said set entity are exposed on the
+        bottom or top of the extruded set.  The section encodes the
+        number of entities in each entity column, and their offset
+        from the start of the set."""
+        _argtype = ctypes.POINTER(_EntityMask)
+
+        @cached_property
+        def handle(self):
+            struct = _EntityMask()
+            struct.section = self.section.handle
+            struct.bottom = self.bottom.handle
+            struct.top = self.top.handle
+            return ctypes.pointer(struct)
+
     @cached_property
     def parent(self):
         return self._parent
@@ -936,7 +953,7 @@ class Subset(ExtrudedSet):
     def masks(self):
         if self._superset.masks is None:
             return None
-        (pbottom, ptop), psection = self._superset.masks
+        psection, pbottom, ptop = self._superset.masks
         # Avoid importing PETSc directly!
         section = type(psection)().create(comm=MPI.COMM_SELF)
         section.setChart(0, self.total_size)
@@ -953,7 +970,7 @@ class Subset(ExtrudedSet):
                 idx += 1
             section.setDof(i, nval)
         section.setUp()
-        return (bottom, top), section
+        return ExtrudedSet.EntityMask(section, bottom, top)
 
     @cached_property
     def _argtype(self):
@@ -2813,7 +2830,7 @@ class Map(object):
 
     @validate_type(('iterset', Set, SetTypeError), ('toset', Set, SetTypeError),
                    ('arity', numbers.Integral, ArityTypeError), ('name', str, NameTypeError))
-    def __init__(self, iterset, toset, arity, values=None, name=None, offset=None, parent=None, bt_masks=None):
+    def __init__(self, iterset, toset, arity, values=None, name=None, offset=None, parent=None, boundary_masks=None):
         self._iterset = iterset
         self._toset = toset
         self.comm = toset.comm
@@ -2834,16 +2851,18 @@ class Map(object):
         self._cache = {}
         # Which indices in the extruded map should be masked out for
         # the application of strong boundary conditions
-        self._bottom_mask = {}
-        self._top_mask = {}
-
-        if offset is not None and bt_masks is not None:
-            for name, mask in bt_masks.items():
-                self._bottom_mask[name] = np.zeros(len(offset), dtype=IntType)
-                self._bottom_mask[name][mask[0]] = -1
-                self._top_mask[name] = np.zeros(len(offset), dtype=IntType)
-                self._top_mask[name][mask[1]] = -1
+        self.boundary_masks = boundary_masks
         Map._globalcount += 1
+
+    class MapMask(namedtuple("_MapMask_", ["section", "indices", "facet_points"])):
+        _argtype = ctypes.POINTER(_MapMask)
+
+        @cached_property
+        def handle(self):
+            struct = _MapMask()
+            struct.section = self.section.handle
+            struct.indices = self.indices.ctypes.data
+            return ctypes.pointer(struct)
 
     @validate_type(('index', (int, IterationIndex), IndexTypeError))
     def __getitem__(self, index):
@@ -2948,15 +2967,31 @@ class Map(object):
         """The vertical offset."""
         return self._offset
 
+    def _constant_layer_masks(self, which):
+        if self.offset is None:
+            return {}
+        idx = {"bottom": -2, "top": -1}[which]
+        masks = {}
+        for method, (section, indices, facet_indices) in self.boundary_masks.items():
+            facet = facet_indices[idx]
+            off = section.getOffset(facet)
+            dof = section.getDof(facet)
+            section.getDof(facet)
+            indices = indices[off:off+dof]
+            mask = np.zeros(len(self.offset), dtype=IntType)
+            mask[indices] = -1
+            masks[method] = mask
+        return masks
+
     @cached_property
     def top_mask(self):
         """The top layer mask to be applied on a mesh cell."""
-        return self._top_mask
+        return self._constant_layer_masks("top")
 
     @cached_property
     def bottom_mask(self):
         """The bottom layer mask to be applied on a mesh cell."""
-        return self._bottom_mask
+        return self._constant_layer_masks("bottom")
 
     def __str__(self):
         return "OP2 Map: %s from (%s) to (%s) with arity %s" \

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -925,6 +925,13 @@ class Subset(ExtrudedSet):
         return self._indices
 
     @cached_property
+    def layers_array(self):
+        if self._superset.constant_layers:
+            return self._superset.layers_array
+        else:
+            return self._superset.layers_array[self.indices, ...]
+
+    @cached_property
     def _argtype(self):
         """Ctypes argtype for this :class:`Subset`"""
         return ctypes.c_voidp

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -795,7 +795,7 @@ class ExtrudedSet(Set):
     """
 
     @validate_type(('parent', Set, TypeError))
-    def __init__(self, parent, layers):
+    def __init__(self, parent, layers, masks=None):
         self._parent = parent
         try:
             layers = verify_reshape(layers, IntType, (parent.total_size, 2))
@@ -815,6 +815,7 @@ class ExtrudedSet(Set):
             layers = np.asarray([[0, layers]], dtype=IntType)
             self.constant_layers = True
 
+        self.masks = masks
         self._layers = layers
         self._extruded = True
 
@@ -930,6 +931,29 @@ class Subset(ExtrudedSet):
             return self._superset.layers_array
         else:
             return self._superset.layers_array[self.indices, ...]
+
+    @cached_property
+    def masks(self):
+        if self._superset.masks is None:
+            return None
+        (pbottom, ptop), psection = self._superset.masks
+        # Avoid importing PETSc directly!
+        section = type(psection)().create(comm=MPI.COMM_SELF)
+        section.setChart(0, self.total_size)
+        shape = (np.sum(self.layers_array[:, 1] - self.layers_array[:, 0] - 1), ) + pbottom.shape[1:]
+        bottom = np.zeros(shape, dtype=pbottom.dtype)
+        top = np.zeros_like(bottom)
+        idx = 0
+        for i, pidx in enumerate(self.indices):
+            offset = psection.getOffset(pidx)
+            nval = self.layers_array[i, 1] - self.layers_array[i, 0] - 1
+            for j in range(nval):
+                bottom[idx] = pbottom[offset + j]
+                top[idx] = ptop[offset + j]
+                idx += 1
+            section.setDof(i, nval)
+        section.setUp()
+        return (bottom, top), section
 
     @cached_property
     def _argtype(self):

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -583,6 +583,8 @@ class Set(object):
     _OWNED_SIZE = 1
     _GHOST_SIZE = 2
 
+    masks = None
+
     @validate_type(('size', (numbers.Integral, tuple, list, np.ndarray), SizeTypeError),
                    ('name', str, NameTypeError))
     def __init__(self, size, name=None, halo=None, comm=None):
@@ -846,8 +848,8 @@ class ExtrudedSet(Set):
         def handle(self):
             struct = _EntityMask()
             struct.section = self.section.handle
-            struct.bottom = self.bottom.handle
-            struct.top = self.top.handle
+            struct.bottom = self.bottom.ctypes.data
+            struct.top = self.top.ctypes.data
             return ctypes.pointer(struct)
 
     @cached_property

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2778,11 +2778,10 @@ class Map(object):
 
     For extruded problems (where ``iterset`` is an
     :class:`ExtrudedSet`) with boundary conditions applied at the top
-    and bottom of the domain, one needs to provide a list of which of
-    the `arity` values in each map entry correspond to values on the
-    bottom boundary and which correspond to the top.  This is done by
-    supplying two lists of indices in `bt_masks`, the first provides
-    indices for the bottom, the second for the top.
+    and bottom of the domain, ``bt_masks`` should be a :class:`dict`
+    mapping boundary condition types to a 2-tuple of masks that should
+    be applied to switch off respectively the "bottom" and "top" nodes
+    of a cell.
 
     """
 

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -584,7 +584,7 @@ class Set(object):
 
     @validate_type(('size', (numbers.Integral, tuple, list, np.ndarray), SizeTypeError),
                    ('name', str, NameTypeError))
-    def __init__(self, size=None, name=None, halo=None, comm=None):
+    def __init__(self, size, name=None, halo=None, comm=None):
         self.comm = dup_comm(comm)
         if isinstance(size, numbers.Integral):
             size = [size] * 3

--- a/pyop2/datatypes.py
+++ b/pyop2/datatypes.py
@@ -39,3 +39,14 @@ def as_ctypes(dtype):
             "uint64": ctypes.c_uint64,
             "float32": ctypes.c_float,
             "float64": ctypes.c_double}[numpy.dtype(dtype).name]
+
+
+class _MapMask(ctypes.Structure):
+    _fields_ = [("section", ctypes.c_voidp),
+                ("indices", ctypes.c_voidp)]
+
+
+class _EntityMask(ctypes.Structure):
+    _fields_ = [("section", ctypes.c_voidp),
+                ("bottom", ctypes.c_voidp),
+                ("top", ctypes.c_voidp)]

--- a/pyop2/fusion/extended.py
+++ b/pyop2/fusion/extended.py
@@ -101,7 +101,7 @@ class FusionArg(sequential.Arg):
         else:
             return super(FusionArg, self).c_vec_init(is_top, is_facet)
 
-    def c_kernel_arg(self, count, i=0, j=0, shape=(0,), layers=1):
+    def c_kernel_arg(self, count, i=0, j=0, shape=(0,)):
         if self.gather == 'postponed':
             if self._is_indirect:
                 c_args = "%s, %s" % (self.c_arg_name(i),
@@ -111,7 +111,7 @@ class FusionArg(sequential.Arg):
         elif self.gather == 'onlymap':
             c_args = "%s, %s" % (self.c_arg_name(i), self.c_vec_name())
         else:
-            c_args = super(FusionArg, self).c_kernel_arg(count, i, j, shape, layers)
+            c_args = super(FusionArg, self).c_kernel_arg(count, i, j, shape)
         if self.c_index:
             c_args += ", %s" % self.c_def_index()
         return c_args

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -983,7 +983,6 @@ def wrapper_snippets(itspace, args,
     _iterset_masks = ""
     _entity_offset = ""
     _get_mask_indices = ""
-    _restore_mask_indices = ""
     if itspace._extruded:
         _layer_arg = ", %s *layers" % as_cstr(IntType)
         if itspace.iterset.constant_layers:

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -979,9 +979,12 @@ def wrapper_snippets(itspace, args,
             else:
                 idx0 = "2*i"
                 idx1 = "2*i+1"
-            _iterset_masks = "struct EntityMask *iterset_masks,"
+            if itspace.iterset.masks is not None:
+                _iterset_masks = "struct EntityMask *iterset_masks,"
             for arg in args:
                 if arg._is_mat and any(len(m.implicit_bcs) > 0 for map in as_tuple(arg.map) for m in map):
+                    if itspace.iterset_masks.masks is None:
+                        raise RuntimeError("Somehow iteration set has no masks, but they are needed")
                     _entity_offset = "PetscInt entity_offset;\n"
                     _entity_offset += "ierr = PetscSectionGetOffset(iterset_masks->section, n, &entity_offset);CHKERRQ(ierr);\n"
                     get_tmp = ["const PetscInt *bottom_masks;",

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -149,7 +149,7 @@ class Arg(base.Arg):
              'var': var if var else 'i',
              'arity': self.map.split[i].arity,
              'idx': idx,
-             'top': ' + start_layer' if is_top else '',
+             'top': ' + (start_layer - bottom_layer)' if is_top else '',
              'dim': self.data[i].cdim,
              'off': ' + %d' % j if j else '',
              'off_mul': ' * %d' % offset if is_top and offset is not None else '',
@@ -431,7 +431,7 @@ for ( int i = 0; i < %(dim)s; i++ ) %(combine)s;
                                {'name': self.c_map_name(i, j),
                                 'dim': m.arity,
                                 'ind': idx,
-                                'off_top': ' + start_layer * '+str(m.offset[idx]) if is_top else ''})
+                                'off_top': ' + (start_layer - bottom_layer) * '+str(m.offset[idx]) if is_top else ''})
                 if is_facet:
                     for idx in range(m.arity):
                         val.append("xtr_%(name)s[%(ind)s] = *(%(name)s + i * %(dim)s + %(ind_zero)s)%(off_top)s%(off)s;" %
@@ -439,7 +439,7 @@ for ( int i = 0; i < %(dim)s; i++ ) %(combine)s;
                                     'dim': m.arity,
                                     'ind': idx + m.arity,
                                     'ind_zero': idx,
-                                    'off_top': ' + start_layer' if is_top else '',
+                                    'off_top': ' + (start_layer - bottom_layer)' if is_top else '',
                                     'off': ' + ' + str(m.offset[idx])})
         return '\n'.join(val)+'\n'
 
@@ -447,8 +447,8 @@ for ( int i = 0; i < %(dim)s; i++ ) %(combine)s;
         maps = as_tuple(self.map, Map)
         val = []
         val.append("for (int facet = 0; facet < %d; facet++) {" % (2 if is_facet else 1))
-        val.append("const int64_t bottom_mask = bottom_masks[entity_offset + j_0 + facet];")
-        val.append("const int64_t top_mask = top_masks[entity_offset + j_0 + facet];")
+        val.append("const int64_t bottom_mask = bottom_masks[entity_offset + j_0 - bottom_layer + facet];")
+        val.append("const int64_t top_mask = top_masks[entity_offset + j_0 - bottom_layer + facet];")
         bottom_masking = []
         top_masking = []
         chart = None

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -445,7 +445,7 @@ for ( int i = 0; i < %(dim)s; i++ ) %(combine)s;
 
     def c_map_bcs_variable(self, sign, is_facet):
         if is_facet:
-            raise NotImplementedError
+            raise NotImplementedError("Haven't figured out to do facet integrals yet")
         maps = as_tuple(self.map, Map)
         val = []
         if sign == "-":

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -447,8 +447,6 @@ for ( int i = 0; i < %(dim)s; i++ ) %(combine)s;
         maps = as_tuple(self.map, Map)
         val = []
         val.append("for (int facet = 0; facet < %d; facet++) {" % (2 if is_facet else 1))
-        val.append("const int64_t bottom_mask = bottom_masks[entity_offset + j_0 - bottom_layer + facet];")
-        val.append("const int64_t top_mask = top_masks[entity_offset + j_0 - bottom_layer + facet];")
         bottom_masking = []
         top_masking = []
         chart = None
@@ -482,8 +480,10 @@ for ( int i = 0; i < %(dim)s; i++ ) %(combine)s;
             # No implicit bcs found
             return ""
         if len(bottom_masking) > 0:
+            val.append("const int64_t bottom_mask = bottom_masks[entity_offset + j_0 - bottom_layer + facet];")
             val.append("\n".join(bottom_masking))
         if len(top_masking) > 0:
+            val.append("const int64_t top_mask = top_masks[entity_offset + j_0 - bottom_layer + facet];")
             val.append("\n".join(top_masking))
         val.append("}")
         return "\n".join(val)

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -444,14 +444,11 @@ for ( int i = 0; i < %(dim)s; i++ ) %(combine)s;
         return '\n'.join(val)+'\n'
 
     def c_map_bcs_variable(self, sign, is_facet):
-        if is_facet:
-            raise NotImplementedError("Haven't figured out to do facet integrals yet")
         maps = as_tuple(self.map, Map)
         val = []
-        if sign == "-":
-            val.append("const PetscInt bottom_mask = bottom_masks[entity_offset + j_0];")
-            val.append("const PetscInt top_mask = top_masks[entity_offset + j_0];")
-            val.append("PetscInt dof, off;")
+        val.append("for (int facet = 0; facet < %d; facet++) {" % (2 if is_facet else 1))
+        val.append("const int64_t bottom_mask = bottom_masks[entity_offset + j_0 + facet];")
+        val.append("const int64_t top_mask = top_masks[entity_offset + j_0 + facet];")
         bottom_masking = []
         top_masking = []
         chart = None
@@ -465,15 +462,18 @@ for ( int i = 0; i < %(dim)s; i++ ) %(combine)s;
                         chart = m.boundary_masks[method].section.getChart()
                     else:
                         assert chart == m.boundary_masks[method].section.getChart()
-                    tmp = []
-                    tmp.append("ierr = PetscSectionGetDof(%(map_name)s_mask->section, bit, &dof); CHKERRQ(ierr);")
-                    tmp.append("ierr = PetscSectionGetOffset(%(map_name)s_mask->section, bit, &off); CHKERRQ(ierr);")
-                    tmp.append("for (int k = off; k < off + dof; k++) {")
-                    tmp.append("    xtr_%(map_name)s[%(map_name)s_mask_indices[k]] %(sign)s= 10000000;")
-                    tmp.append("}")
-                    tmp = "\n".join(tmp) % {"map_name": map_name,
-                                            "name": location,
-                                            "sign": sign}
+                    tmp = """apply_extruded_mask(%(map_name)s_mask->section,
+                                                 %(map_name)s_mask_indices,
+                                                 %(mask_name)s,
+                                                 facet*%(facet_offset)s,
+                                                 %(nbits)s,
+                                                 %(sign)s10000000,
+                                                 xtr_%(map_name)s);""" % \
+                          {"map_name": map_name,
+                           "mask_name": "%s_mask" % location,
+                           "facet_offset": m.arity,
+                           "nbits": chart[1],
+                           "sign": sign}
                     if location == "bottom":
                         bottom_masking.append(tmp)
                     else:
@@ -481,15 +481,10 @@ for ( int i = 0; i < %(dim)s; i++ ) %(combine)s;
         if chart is None:
             # No implicit bcs found
             return ""
-        val.append("for (int bit = %d; bit < %d; bit++) {" % chart)
         if len(bottom_masking) > 0:
-            val.append("    if (bottom_mask & (1L<<bit)) {")
-            val.append("        \n".join(bottom_masking))
-            val.append("    }")
+            val.append("\n".join(bottom_masking))
         if len(top_masking) > 0:
-            val.append("    if (top_mask & (1L<<bit)) {")
-            val.append("        \n".join(top_masking))
-            val.append("    }")
+            val.append("\n".join(top_masking))
         val.append("}")
         return "\n".join(val)
 
@@ -623,14 +618,38 @@ struct MapMask {
     /* Row pointer */
     PetscSection section;
     /* Indices */
-    IS           indices;
+    const PetscInt *indices;
 };
 
 struct EntityMask {
     PetscSection section;
-    IS           bottom;
-    IS           top;
+    const int64_t *bottom;
+    const int64_t *top;
 };
+
+static PetscErrorCode apply_extruded_mask(PetscSection section,
+                                          const PetscInt mask_indices[],
+                                          const int64_t mask,
+                                          const int facet_offset,
+                                          const int nbits,
+                                          const int value_offset,
+                                          PetscInt map[])
+{
+    PetscErrorCode ierr;
+    PetscInt dof, off;
+    /* Shortcircuit for interior cells */
+    if (!mask) return 0;
+    for (int bit = 0; bit < nbits; bit++) {
+        if (mask & (1L<<bit)) {
+            ierr = PetscSectionGetDof(section, bit, &dof); CHKERRQ(ierr);
+            ierr = PetscSectionGetOffset(section, bit, &off); CHKERRQ(ierr);
+            for (int k = off; k < off + dof; k++) {
+                map[mask_indices[k] + facet_offset] += value_offset;
+            }
+        }
+    }
+    return 0;
+}
 
 PetscErrorCode %(wrapper_name)s(int start,
                       int end,
@@ -660,7 +679,6 @@ PetscErrorCode %(wrapper_name)s(int start,
     %(apply_offset)s;
     %(extr_loop_close)s
   }
-  %(restore_mask_indices)s;
   return 0;
 }
 """
@@ -811,10 +829,10 @@ PetscErrorCode %(wrapper_name)s(int start,
     def set_argtypes(self, iterset, *args):
         index_type = as_ctypes(IntType)
         argtypes = [index_type, index_type]
-        if isinstance(iterset, Subset):
-            argtypes.append(iterset._argtype)
         if iterset.masks is not None:
             argtypes.append(iterset.masks._argtype)
+        if isinstance(iterset, Subset):
+            argtypes.append(iterset._argtype)
         for arg in args:
             if arg._is_mat:
                 argtypes.append(arg.data._argtype)
@@ -846,10 +864,10 @@ class ParLoop(petsc_base.ParLoop):
 
     def prepare_arglist(self, iterset, *args):
         arglist = []
-        if isinstance(iterset, Subset):
-            arglist.append(iterset._indices.ctypes.data)
         if iterset.masks is not None:
             arglist.append(iterset.masks.handle)
+        if isinstance(iterset, Subset):
+            arglist.append(iterset._indices.ctypes.data)
         for arg in args:
             if arg._is_mat:
                 arglist.append(arg.data.handle.handle)
@@ -983,25 +1001,18 @@ def wrapper_snippets(itspace, args,
                 _iterset_masks = "struct EntityMask *iterset_masks,"
             for arg in args:
                 if arg._is_mat and any(len(m.implicit_bcs) > 0 for map in as_tuple(arg.map) for m in map):
-                    if itspace.iterset_masks.masks is None:
+                    if itspace.iterset.masks is None:
                         raise RuntimeError("Somehow iteration set has no masks, but they are needed")
                     _entity_offset = "PetscInt entity_offset;\n"
                     _entity_offset += "ierr = PetscSectionGetOffset(iterset_masks->section, n, &entity_offset);CHKERRQ(ierr);\n"
-                    get_tmp = ["const PetscInt *bottom_masks;",
-                               "const PetscInt *top_masks;",
-                               "ierr = ISGetIndices(iterset_masks->bottom, &bottom_masks); CHKERRQ(ierr);",
-                               "ierr = ISGetIndices(iterset_masks->top, &top_masks); CHKERRQ(ierr);"]
-                    restore_tmp = ["ierr = ISRestoreIndices(iterset_masks->bottom, &bottom_masks); CHKERRQ(ierr);",
-                                   "ierr = ISRestoreIndices(iterset_masks->top, &top_masks); CHKERRQ(ierr);"]
+                    get_tmp = ["const int64_t *bottom_masks = iterset_masks->bottom;",
+                               "const int64_t *top_masks = iterset_masks->top;"]
                     for i, map in enumerate(as_tuple(arg.map)):
                         for j, m in enumerate(map):
                             if m.implicit_bcs:
                                 name = "%s_mask_indices" % arg.c_map_name(i, j)
-                                get_tmp.append("const PetscInt *%s;" % name)
-                                get_tmp.append("ierr = ISGetIndices(%s_mask->indices, &%s); CHKERRQ(ierr);" % (arg.c_map_name(i, j), name))
-                                restore_tmp.append("ierr = ISRestoreIndices(%s_mask->indices, &%s); CHKERRQ(ierr);" % (arg.c_map_name(i, j), name))
+                                get_tmp.append("const PetscInt *%s = %s_mask->indices;" % (name, arg.c_map_name(i, j)))
                     _get_mask_indices = "\n".join(get_tmp)
-                    _restore_mask_indices = "\n".join(restore_tmp)
                     break
         _layer_decls = "%(IntType)s bottom_layer = layers[%(idx0)s];\n"
         if iteration_region == ON_BOTTOM:
@@ -1159,7 +1170,6 @@ def wrapper_snippets(itspace, args,
             'vec_inits': indent(_vec_inits, 2),
             'entity_offset': indent(_entity_offset, 2),
             'get_mask_indices': indent(_get_mask_indices, 1),
-            'restore_mask_indices': indent(_restore_mask_indices, 1),
             'layer_arg': _layer_arg,
             'map_decl': indent(_map_decl, 2),
             'vec_decs': indent(_vec_decs, 2),

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -882,8 +882,13 @@ def wrapper_snippets(itspace, args,
             idx0 = "0"
             idx1 = "1"
         else:
-            idx0 = "2*i"
-            idx1 = "2*i+1"
+            if isinstance(itspace.iterset, Subset):
+                # Subset doesn't hold full layer array
+                idx0 = "2*n"
+                idx1 = "2*n+1"
+            else:
+                idx0 = "2*i"
+                idx1 = "2*i+1"
         _layer_decls = "%(IntType)s bottom_layer = layers[%(idx0)s];\n"
         if iteration_region == ON_BOTTOM:
             _layer_decls += "%(IntType)s start_layer = layers[%(idx0)s];\n"


### PR DESCRIPTION
Support providing a variable number of layers for extruded sets.  Each entity can separately specify the start and stop layers now.  Appears safe to merge for firedrake without changes on that side (since legacy interface is backwards compatible).

Are we happy with the interface?