### PR TITLE
Define infix operators on Globals

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2792,8 +2792,6 @@ class Global(DataCarrier, _EmptyDataMixin):
         """Pointwise division or scaling of fields."""
         return self._op(other, operator.truediv)
 
-    __div__ = __truediv__  # Python 2 compatibility
-
     def __iadd__(self, other):
         """Pointwise addition of fields."""
         return self._iop(other, operator.iadd)
@@ -2809,8 +2807,6 @@ class Global(DataCarrier, _EmptyDataMixin):
     def __itruediv__(self, other):
         """Pointwise division or scaling of fields."""
         return self._iop(other, operator.itruediv)
-
-    __idiv__ = __itruediv__  # Python 2 compatibility
 
 
 class IterationIndex(object):

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2734,6 +2734,84 @@ class Global(DataCarrier, _EmptyDataMixin):
         part of a :class:`MixedDat`."""
         pass
 
+    def _op(self, other, op):
+        ret = type(self)(self.dim, dtype=self.dtype, name=self.name)
+        if isinstance(other, Global):
+            ret.data[:] = op(self.data_ro, other.data_ro)
+        else:
+            ret.data[:] = op(self.data_ro, other)
+        return ret
+
+    def _iop(self, other, op):
+        if isinstance(other, Global):
+            op(self.data[:], other.data_ro)
+        else:
+            op(self.data[:], other)
+        return self
+
+    def __pos__(self):
+        return self.duplicate()
+
+    def __add__(self, other):
+        """Pointwise addition of fields."""
+        return self._op(other, operator.add)
+
+    def __radd__(self, other):
+        """Pointwise addition of fields.
+
+        self.__radd__(other) <==> other + self."""
+        return self + other
+
+    def __neg__(self):
+        return type(self)(self.dim, data=-np.copy(self.data_ro),
+                          dtype=self.dtype, name=self.name)
+
+    def __sub__(self, other):
+        """Pointwise subtraction of fields."""
+        return self._op(other, operator.sub)
+
+    def __rsub__(self, other):
+        """Pointwise subtraction of fields.
+
+        self.__rsub__(other) <==> other - self."""
+        ret = -self
+        ret += other
+        return ret
+
+    def __mul__(self, other):
+        """Pointwise multiplication or scaling of fields."""
+        return self._op(other, operator.mul)
+
+    def __rmul__(self, other):
+        """Pointwise multiplication or scaling of fields.
+
+        self.__rmul__(other) <==> other * self."""
+        return self.__mul__(other)
+
+    def __truediv__(self, other):
+        """Pointwise division or scaling of fields."""
+        return self._op(other, operator.truediv)
+
+    __div__ = __truediv__  # Python 2 compatibility
+
+    def __iadd__(self, other):
+        """Pointwise addition of fields."""
+        return self._iop(other, operator.iadd)
+
+    def __isub__(self, other):
+        """Pointwise subtraction of fields."""
+        return self._iop(other, operator.isub)
+
+    def __imul__(self, other):
+        """Pointwise multiplication or scaling of fields."""
+        return self._iop(other, operator.imul)
+
+    def __itruediv__(self, other):
+        """Pointwise division or scaling of fields."""
+        return self._iop(other, operator.itruediv)
+
+    __idiv__ = __itruediv__  # Python 2 compatibility
+
 
 class IterationIndex(object):
 

--- a/test/unit/test_globals.py
+++ b/test/unit/test_globals.py
@@ -1,0 +1,49 @@
+# This file is part of PyOP2
+#
+# PyOP2 is Copyright (c) 2012, Imperial College London and
+# others. Please see the AUTHORS file in the main source directory for
+# a full list of copyright holders.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * The name of Imperial College London or that of other
+#       contributors may not be used to endorse or promote products
+#       derived from this software without specific prior written
+#       permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTERS
+# ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import, print_function, division
+
+
+from pyop2 import op2
+
+
+def test_global_operations():
+    g1 = op2.Global(1, data=2.)
+    g2 = op2.Global(1, data=5.)
+
+    assert (g1 + g2).data == 7.
+    assert (g2 - g1).data == 3.
+    assert (-g2).data == -5.
+    assert (g1 * g2).data == 10.
+    g1 *= g2
+    assert g1.data == 10.

--- a/test/unit/test_globals.py
+++ b/test/unit/test_globals.py
@@ -31,9 +31,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import absolute_import, print_function, division
-
-
 from pyop2 import op2
 
 


### PR DESCRIPTION
This fixes issues where operations on Firedrake Functions in the R space assume that the usual operators are defined for Globals.