### PR TITLE
Flush stderr before calling MPI_Abort()

### DIFF
--- a/pyop2/mpi.py
+++ b/pyop2/mpi.py
@@ -230,5 +230,6 @@ if COMM_WORLD.size > 1:
 
     def mpi_excepthook(typ, value, traceback):
         except_hook(typ, value, traceback)
+        sys.stderr.flush()
         COMM_WORLD.Abort(1)
     sys.excepthook = mpi_excepthook


### PR DESCRIPTION
This fixes the fact that in parallel exception messages and tracebacks
were no longer printed since python3.