### PR TITLE
Allow MIN and MAX accessors on Dats

### DIFF
--- a/pyop2/datatypes.py
+++ b/pyop2/datatypes.py
@@ -50,3 +50,21 @@ class _EntityMask(ctypes.Structure):
     _fields_ = [("section", ctypes.c_voidp),
                 ("bottom", ctypes.c_voidp),
                 ("top", ctypes.c_voidp)]
+
+
+def dtype_limits(dtype):
+    """Attempt to determine the min and max values of a datatype.
+
+    :arg dtype: A numpy datatype.
+    :returns: a 2-tuple of min, max
+    :raises ValueError: If numeric limits could not be determined.
+    """
+    try:
+        info = numpy.finfo(dtype)
+    except ValueError:
+        # maybe an int?
+        try:
+            info = numpy.iinfo(dtype)
+        except ValueError as e:
+            raise ValueError("Unable to determine numeric limits from %s" % dtype) from e
+    return info.min, info.max

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -790,12 +790,6 @@ class TestDatAPI:
         d = op2.Dat(dset, dtype=np.int32)
         assert d.data.dtype == np.int32
 
-    @pytest.mark.parametrize("mode", [op2.MAX, op2.MIN])
-    def test_dat_arg_illegal_mode(self, dat, mode):
-        """Dat __call__ should not allow access modes not allowed for a Dat."""
-        with pytest.raises(exceptions.ModeValueError):
-            dat(mode)
-
     def test_dat_subscript(self, dat):
         """Extracting component 0 of a Dat should yield self."""
         assert dat[0] is dat


### PR DESCRIPTION
The local access is treated like RW, but the global_to_local and
local_to_global exchanges are different.  The former fills ghost
regions with an appropriate large or small value, the latter performs
a reduction with the appropriate MPI op.