### PR TITLE
Compilation: wait more to make sure the .so file exists on disk

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -39,6 +39,7 @@ import ctypes
 import collections
 from hashlib import md5
 from distutils import version
+from time import sleep
 
 
 from pyop2.mpi import MPI, collective, COMM_WORLD
@@ -266,6 +267,12 @@ Compile errors in %s""" % (e.cmd, e.returncode, logfile, errfile))
                     os.rename(tmpname, soname)
             # Wait for compilation to complete
             self.comm.barrier()
+            if not os.path.isfile(soname):
+                # Wait more if .so file is not visible on disk
+                for i in range(60):
+                    sleep(1.0)
+                    if os.path.isfile(soname):
+                        break
             # Load resulting library
             return ctypes.CDLL(soname)
 


### PR DESCRIPTION
As mentioned in firedrakeproject/firedrake#1145, compilation in parallel may fail in case some ranks do not see the .so file immediately.

This patch adds a check of the existence of the file, and an additional wait up to 60 s. Should not introduce much overhead in systems where the issue does not occur; there's only one additional `os.path.isfile` check at compile time.