### PR TITLE
Fix Intel compiler version detection

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -75,7 +75,7 @@ def sniff_compiler_version(cc):
     elif ver.startswith("Apple LLVM"):
         compiler = "clang"
     elif ver.startswith("icc"):
-        compiler = "intel"
+        compiler = "icc"
     else:
         compiler = "unknown"
 


### PR DESCRIPTION
I'm stealing the ``sniff_compiler_version`` utility function.

I guess you meant ``icc``, rather than ``intel`` ?