### PR TITLE
Some fixes for problems on `V x R` on subcommunicators

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2134,11 +2134,17 @@ class MixedDat(Dat):
     """
 
     def __init__(self, mdset_or_dats):
+        def what(x):
+            if isinstance(x, Dat):
+                return "Dat"
+            elif isinstance(x, Global):
+                return "Global"
+            else:
+                raise DataValueError("Huh?!")
         if isinstance(mdset_or_dats, MixedDat):
-            self._dats = tuple(_make_object('Dat', d) for d in mdset_or_dats)
+            self._dats = tuple(_make_object(what(d), d) for d in mdset_or_dats)
         else:
-            self._dats = tuple(d if isinstance(d, (Dat, Global)) else _make_object('Dat', d)
-                               for d in mdset_or_dats)
+            self._dats = tuple(d if isinstance(d, (Dat, Global)) else _make_object(what(d), d) for d in mdset_or_dats)
         if not all(d.dtype == self._dats[0].dtype for d in self._dats):
             raise DataValueError('MixedDat with different dtypes is not supported')
         # TODO: Think about different communicators on dats (c.f. MixedSet)

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1800,7 +1800,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
                % (self._dataset, self.dtype, self._name)
 
     def _check_shape(self, other):
-        if other.dataset != self.dataset:
+        if other.dataset.dim != self.dataset.dim:
             raise ValueError('Mismatched shapes in operands %s and %s',
                              self.dataset.dim, other.dataset.dim)
 

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2561,7 +2561,7 @@ class Global(DataCarrier, _EmptyDataMixin):
         pass
 
     def _op(self, other, op):
-        ret = type(self)(self.dim, dtype=self.dtype, name=self.name)
+        ret = type(self)(self.dim, dtype=self.dtype, name=self.name, comm=self.comm)
         if isinstance(other, Global):
             ret.data[:] = op(self.data_ro, other.data_ro)
         else:

--- a/pyop2/petsc_base.py
+++ b/pyop2/petsc_base.py
@@ -1092,15 +1092,15 @@ def _GlobalMat(global_=None, comm=None):
     """A :class:`PETSc.Mat` with global size 1x1 implemented as a
     :class:`.Global`"""
     A = PETSc.Mat().createPython(((None, 1), (None, 1)), comm=comm)
-    A.setPythonContext(_GlobalMatPayload(global_))
+    A.setPythonContext(_GlobalMatPayload(global_, comm))
     A.setUp()
     return A
 
 
 class _GlobalMatPayload(object):
 
-    def __init__(self, global_=None):
-        self.global_ = global_ or _make_object("Global", 1)
+    def __init__(self, global_=None, comm=None):
+        self.global_ = global_ or _make_object("Global", 1, comm=comm)
 
     def __getitem__(self, key):
         return self.global_.data_ro.reshape(1, 1)[key]


### PR DESCRIPTION
I have a problem to solve on a `FunctionSpace(mesh, "Hermite, 3) x FunctionSpace(mesh, "R", 0)` in defcon. This branch collects some necessary fixes:

1. Pass around some communicators to fix `COMM_WORLD` deadlocks.
2. Fix `MixedDat` construction from `[Dat, Global]`.
3. Fix the checking of shape compability on `Dat`s when the dataset is a `Global`. (Previously firedrake would complain that it can't add two functions, even though they have a compatible layout, because the dataset for a `Global` is recreated each time.)