### PR TITLE
Fix/access init

### DIFF
--- a/pyop2/codegen/builder.py
+++ b/pyop2/codegen/builder.py
@@ -185,11 +185,11 @@ class DatPack(Pack):
         if self.view_index is None:
             shape = shape + self.outer.shape[1:]
 
-        if self.access in {INC, WRITE, MIN, MAX}:
+        if self.access in {INC, WRITE}:
             val = Zero((), self.outer.dtype)
             multiindex = MultiIndex(*(Index(e) for e in shape))
             self._pack = Materialise(PackInst(), val, multiindex)
-        elif self.access in {READ, RW}:
+        elif self.access in {READ, RW, MIN, MAX}:
             multiindex = MultiIndex(*(Index(e) for e in shape))
             expr, mask = self._rvalue(multiindex, loop_indices=loop_indices)
             if mask is not None:
@@ -262,11 +262,11 @@ class MixedDatPack(Pack):
         else:
             _shape = (1,)
 
-        if self.access in {INC, WRITE, MIN, MAX}:
+        if self.access in {INC, WRITE}:
             val = Zero((), self.dtype)
             multiindex = MultiIndex(Index(flat_shape))
             self._pack = Materialise(PackInst(), val, multiindex)
-        elif self.access in {READ, RW}:
+        elif self.access in {READ, RW, MIN, MAX}:
             multiindex = MultiIndex(Index(flat_shape))
             val = Zero((), self.dtype)
             expressions = []

--- a/test/unit/test_indirect_loop.py
+++ b/test/unit/test_indirect_loop.py
@@ -155,6 +155,28 @@ class TestIndirectLoop:
                      iterset, u(op2.INC, iterset2unitset))
         assert u.data[0] == nelems
 
+    @pytest.mark.xfail(reason="Packs not initialized correctly")
+    def test_indirect_max(self, iterset, indset, iterset2indset):
+        a = op2.Dat(indset, dtype=np.int32)
+        b = op2.Dat(indset, dtype=np.int32)
+        a.data[:] = -10
+        b.data[:] = -5
+        kernel = "static void maxify(int *a, int *b) {*a = *a < *b ? *b : *a;}\n"
+        op2.par_loop(op2.Kernel(kernel, "maxify"),
+                     iterset, a(op2.MAX, iterset2indset), b(op2.READ, iterset2indset))
+        assert np.allclose(a.data_ro, -5)
+
+    @pytest.mark.xfail(reason="Packs not initialized correctly")
+    def test_indirect_min(self, iterset, indset, iterset2indset):
+        a = op2.Dat(indset, dtype=np.int32)
+        b = op2.Dat(indset, dtype=np.int32)
+        a.data[:] = 10
+        b.data[:] = 5
+        kernel = "static void minify(int *a, int *b) {*a = *a > *b ? *b : *a;}\n"
+        op2.par_loop(op2.Kernel(kernel, "minify"),
+                     iterset, a(op2.MIN, iterset2indset), b(op2.READ, iterset2indset))
+        assert np.allclose(a.data_ro, 5)
+
     def test_global_read(self, iterset, x, iterset2indset):
         """Divide a Dat by a Global."""
         g = op2.Global(1, 2, np.uint32, "g")

--- a/test/unit/test_indirect_loop.py
+++ b/test/unit/test_indirect_loop.py
@@ -155,7 +155,6 @@ class TestIndirectLoop:
                      iterset, u(op2.INC, iterset2unitset))
         assert u.data[0] == nelems
 
-    @pytest.mark.xfail(reason="Packs not initialized correctly")
     def test_indirect_max(self, iterset, indset, iterset2indset):
         a = op2.Dat(indset, dtype=np.int32)
         b = op2.Dat(indset, dtype=np.int32)
@@ -166,7 +165,6 @@ class TestIndirectLoop:
                      iterset, a(op2.MAX, iterset2indset), b(op2.READ, iterset2indset))
         assert np.allclose(a.data_ro, -5)
 
-    @pytest.mark.xfail(reason="Packs not initialized correctly")
     def test_indirect_min(self, iterset, indset, iterset2indset):
         a = op2.Dat(indset, dtype=np.int32)
         b = op2.Dat(indset, dtype=np.int32)


### PR DESCRIPTION
MIN and MAX access descriptors need to initialize their packs from the incoming data.