### PR TITLE
Make `as_tuple` more permissive

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1294,7 +1294,7 @@ class MixedDataSet(DataSet, ObjectCached):
         # DataSets and upcast Sets to DataSets as necessary
         else:
             arg = [s if isinstance(s, DataSet) else s ** 1 for s in arg]
-            dsets = as_tuple(arg, type=DataSet)
+            dsets = as_tuple(arg, DataSet)
 
         return (dsets[0].set, ) + (dsets, ), {}
 
@@ -2851,7 +2851,7 @@ class MixedMap(Map, ObjectCached):
 
     @classmethod
     def _process_args(cls, *args, **kwargs):
-        maps = as_tuple(args[0], type=Map, allow_none=True)
+        maps = as_tuple(args[0], typs=Map, allow_none=True)
         cache = maps[0]
         return (cache, ) + (maps, ), kwargs
 

--- a/pyop2/utils.py
+++ b/pyop2/utils.py
@@ -63,7 +63,7 @@ class cached_property(object):
         return result
 
 
-def as_tuple(item, type=None, length=None, allow_none=False):
+def as_tuple(item, typs=None, length=None, allow_none=False):
     # Empty list if we get passed None
     if item is None:
         t = ()
@@ -77,13 +77,16 @@ def as_tuple(item, type=None, length=None, allow_none=False):
     if configuration["type_check"]:
         if length and not len(t) == length:
             raise ValueError("Tuple needs to be of length %d" % length)
-        if type is not None:
+        if typs is not None:
+            try:
+                typs = tuple(typs)
+            except TypeError:
+                typs = tuple((typs,))
             if allow_none:
-                valid = all((isinstance(i, type) or i is None) for i in t)
-            else:
-                valid = all(isinstance(i, type) for i in t)
+                typs += (type(None),)
+            valid = all(any(isinstance(i, typ) for typ in typs) for i in t)
             if not valid:
-                raise TypeError("Items need to be of type %s" % type)
+                raise TypeError("Items need to be one of types %s" % typs)
     return t
 
 


### PR DESCRIPTION
This patch makes the function `utils.as_tuple` accept an iterable of types to check the input item against. That way it can be called to check whether the item members are either an int, a numpy int32, or a numpy int64, rather than just an int. This can address #564 by making the error case less likely.