### PR TITLE
kernel: Add configuration parameter to control kernel.num_flops

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3371,6 +3371,8 @@ class Kernel(Cached):
 
     @cached_property
     def num_flops(self):
+        if not configuration["compute_kernel_flops"]:
+            return 0
         if isinstance(self.code, Node):
             v = EstimateFlops()
             return v.visit(self.code)

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -79,6 +79,7 @@ class Configuration(dict):
         "debug": ("PYOP2_DEBUG", bool, False),
         "cflags": ("PYOP2_CFLAGS", str, ""),
         "ldflags": ("PYOP2_LDFLAGS", str, ""),
+        "compute_kernel_flops": ("PYOP2_COMPUTE_KERNEL_FLOPS", bool, False),
         "type_check": ("PYOP2_TYPE_CHECK", bool, True),
         "check_src_hashes": ("PYOP2_CHECK_SRC_HASHES", bool, True),
         "log_level": ("PYOP2_LOG_LEVEL", (str, int), "WARNING"),


### PR DESCRIPTION
Default off, to avoid loopy slowness.