### PR TITLE
utils: Backport cached property from functools

### DIFF
--- a/pyop2/utils.py
+++ b/pyop2/utils.py
@@ -43,24 +43,49 @@ import argparse
 from pyop2.exceptions import DataTypeError, DataValueError
 from pyop2.configuration import configuration
 
+try:
+    from functools import cached_property
+except ImportError:
+    # Backport from functools 3.8
+    from _thread import RLock
 
-class cached_property(object):
+    _NOT_FOUND = object()
 
-    '''A read-only @property that is only evaluated once. The value is cached
-    on the object itself rather than the function or class; this should prevent
-    memory leakage.'''
+    class cached_property:
+        def __init__(self, func):
+            self.func = func
+            self.attrname = None
+            self.__doc__ = func.__doc__
+            self.lock = RLock()
 
-    def __init__(self, fget, doc=None):
-        self.fget = fget
-        self.__doc__ = doc or fget.__doc__
-        self.__name__ = fget.__name__
-        self.__module__ = fget.__module__
+        def __set_name__(self, owner, name):
+            if self.attrname is None:
+                self.attrname = name
+            elif name != self.attrname:
+                raise TypeError("Cannot assign the same cached_property to two different names")
 
-    def __get__(self, obj, cls):
-        if obj is None:
-            return self
-        obj.__dict__[self.__name__] = result = self.fget(obj)
-        return result
+        def __get__(self, instance, owner=None):
+            if instance is None:
+                return self
+            if self.attrname is None:
+                raise TypeError(
+                    "Cannot use cached_property instance without calling __set_name__ on it.")
+            try:
+                cache = instance.__dict__
+            except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
+                raise TypeError("No '__dict__' attribute to cache property on") from None
+            val = cache.get(self.attrname, _NOT_FOUND)
+            if val is _NOT_FOUND:
+                with self.lock:
+                    # check if another thread filled cache while we awaited lock
+                    val = cache.get(self.attrname, _NOT_FOUND)
+                    if val is _NOT_FOUND:
+                        val = self.func(instance)
+                        try:
+                            cache[self.attrname] = val
+                        except TypeError:
+                            raise TypeError("The '__dict__' attribute does not support assignment for caching") from None
+            return val
 
 
 def as_tuple(item, type=None, length=None, allow_none=False):

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,0 +1,32 @@
+from pyop2.utils import cached_property
+from itertools import count
+
+
+def noop_decorate(fn):
+    def wrapper(self):
+        return fn(self)
+    return wrapper
+
+
+class Cached(object):
+    def __init__(self):
+        self.a = count()
+        self.b = count()
+
+    @cached_property
+    def undecorated(self):
+        return next(self.a)
+
+    @cached_property
+    @noop_decorate
+    def decorated(self):
+        return next(self.b)
+
+
+def test_cached_property():
+    obj = Cached()
+
+    assert obj.undecorated == 0
+    assert obj.undecorated == 0
+    assert obj.decorated == 0
+    assert obj.decorated == 0


### PR DESCRIPTION
Fixes some corner cases of decorator composition with cached_property (c.f. firedrakeproject/firedrake#1567)