### PR TITLE
Fix MixedMap._kernel_args_ with R block

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2656,11 +2656,11 @@ class MixedMap(Map, ObjectCached):
 
     @cached_property
     def _argtypes_(self):
-        return tuple(itertools.chain(*(m._argtypes_ for m in self)))
+        return tuple(itertools.chain(*(m._argtypes_ for m in self if m is not None)))
 
     @cached_property
     def _wrapper_cache_key_(self):
-        return tuple(m._wrapper_cache_key_ for m in self)
+        return tuple(m._wrapper_cache_key_ for m in self if m is not None)
 
     @cached_property
     def split(self):

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2652,7 +2652,7 @@ class MixedMap(Map, ObjectCached):
 
     @cached_property
     def _kernel_args_(self):
-        return tuple(itertools.chain(*(m._kernel_args_ for m in self)))
+        return tuple(itertools.chain(*(m._kernel_args_ for m in self if m is not None)))
 
     @cached_property
     def _argtypes_(self):


### PR DESCRIPTION
Getting the `_kernel_args_` of a `MixedMap` crashes if the mixed function space features an R block. This commit fixes this.

Question for reviewers: should the same `if m is not None` be added everywhere else in `MixedMap`? I'm happy to do this if you agree it's the right thing.