### PR TITLE
Inline callables from loopy programs

### DIFF
--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,4 +1,4 @@
 git+https://github.com/firedrakeproject/petsc.git@firedrake#egg=petsc
 --no-deps git+https://github.com/firedrakeproject/petsc4py.git@firedrake#egg=petsc4py
 git+https://github.com/coneoproject/COFFEE.git#egg=coffee
-git+https://github.com/firedrakeproject/loopy.git@firedrake#egg=loopy
+git+https://github.com/firedrakeproject/loopy.git@allow-callablestables-gen-with-functionsnotinhistory#egg=loopy


### PR DESCRIPTION
This is an attempt of handling multiple kernel as callables stacked into each other. The previous workaround for this was to generate c-code first and then attach the kernel to the pyop2 wrapper kernel, see https://github.com/firedrakeproject/firedrake/blob/418eaea8e307de39983cf9eb60caa8e01d266212/firedrake/slate/slac/compiler.py#L153.

When inlining the TSFC kernel in loopy, the Slate wrapper kernel becomes a Program.

In this PR I attempt to properly inline the Slate kernel in PyOP2. The idea is to first copy or register all resolved functions from the Slate wrapper program to the PyOP2 wrapper program (Copy for example for math functions, register for CallableKernels) and afterwards inline the Slate wrapper Kernel.

I ran into trouble with undefined keys in the history of Programs and a couple of other problems which are addressed in https://github.com/firedrakeproject/loopy/compare/allow-callablestables-gen-with-functionsnotinhistory.

I am not a 100percent sure, that this would be sufficient to inline the Slate wrapper. Does anyone have any comment on this?