### PR TITLE
fix for icc 

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -81,7 +81,7 @@ def sniff_compiler_version(cc):
         compiler = "unknown"
 
     ver = version.LooseVersion("unknown")
-    if compiler in ["gcc", "icc"]:
+    if compiler == "gcc":
         try:
             ver = subprocess.check_output([cc, "-dumpversion"],
                                           stderr=subprocess.DEVNULL).decode("utf-8")


### PR DESCRIPTION
icc --version gives a version of the form a.b.c.d, which python doesn't like (too long)