### PR TITLE
Outsource the linear algebra c functions 

### DIFF
--- a/pyop2/codegen/c/inverse.c
+++ b/pyop2/codegen/c/inverse.c
@@ -1,0 +1,29 @@
+#include <petscsys.h>
+#include <petscblaslapack.h>
+
+#ifndef PYOP2_WORK_ARRAYS
+#define PYOP2_WORK_ARRAYS
+#define BUF_SIZE 30
+static PetscBLASInt ipiv_buffer[BUF_SIZE];
+static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
+#endif
+
+static void inverse(PetscScalar* __restrict__ Aout, const PetscScalar* __restrict__ A, PetscBLASInt N)
+{
+    PetscBLASInt info;
+    PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));
+    PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N*N*sizeof(*Awork));
+    memcpy(Aout, A, N*N*sizeof(PetscScalar));
+    LAPACKgetrf_(&N, &N, Aout, &N, ipiv, &info);
+    if(info == 0){
+        LAPACKgetri_(&N, Aout, &N, ipiv, Awork, &N, &info);
+    }
+    if(info != 0){
+        fprintf(stderr, "Getri throws nonzero info.");
+        abort();
+    }
+    if ( N > BUF_SIZE ) {
+        free(Awork);
+        free(ipiv);
+    }
+}

--- a/pyop2/codegen/c/solve.c
+++ b/pyop2/codegen/c/solve.c
@@ -1,0 +1,33 @@
+#include <petscsys.h>
+#include <petscblaslapack.h>
+
+#ifndef PYOP2_WORK_ARRAYS
+#define PYOP2_WORK_ARRAYS
+#define BUF_SIZE 30
+static PetscBLASInt ipiv_buffer[BUF_SIZE];
+static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
+#endif
+
+static void solve(PetscScalar* __restrict__ out, const PetscScalar* __restrict__ A, const PetscScalar* __restrict__ B, PetscBLASInt N)
+{
+    PetscBLASInt info;
+    PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));
+    memcpy(out,B,N*sizeof(PetscScalar));
+    PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N*N*sizeof(*Awork));
+    memcpy(Awork,A,N*N*sizeof(PetscScalar));
+    PetscBLASInt NRHS = 1;
+    const char T = 'T';
+    LAPACKgetrf_(&N, &N, Awork, &N, ipiv, &info);
+    if(info == 0){
+        LAPACKgetrs_(&T, &N, &NRHS, Awork, &N, ipiv, out, &N, &info);
+    }
+    if(info != 0){
+        fprintf(stderr, "Gesv throws nonzero info.");
+        abort();
+    }
+
+    if ( N > BUF_SIZE ) {
+        free(ipiv);
+        free(Awork);
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ setup(name='PyOP2',
       test_requires=test_requires,
       packages=['pyop2', 'pyop2.codegen'],
       package_data={
-          'pyop2': ['assets/*', '*.h', '*.pxd', '*.pyx']},
+          'pyop2': ['assets/*', '*.h', '*.pxd', '*.pyx', 'codegen/c/*.c']},
       scripts=glob('scripts/*'),
       cmdclass=cmdclass,
       ext_modules=[Extension('pyop2.sparsity', sparsity_sources,


### PR DESCRIPTION
Is there any reason not to outsource the linear algebra c functions (inverse, solve) into separate files and read them in as strings for the preamble of the respective loopy Callable?

That would make it a) easier for me to code them and b) the code in rep2loopy more readable, in particular with more c kernels coming for vectorisation with batched blas and vectorisation without batched blas.