### PR TITLE
codegen: Correct layers array indexing for subsets

### DIFF
--- a/pyop2/codegen/builder.py
+++ b/pyop2/codegen/builder.py
@@ -702,8 +702,6 @@ class WrapperBuilder(object):
     def _layer_index(self):
         if self.constant_layers:
             return FixedIndex(0)
-        if self.subset:
-            return self._loop_index
         else:
             return self.loop_index
 


### PR DESCRIPTION
Subset par_loops pass the layer array of the non-subsetted extruded
set, so we need to index it appropriately (using the loop index after
extracting the subset index, rather than before).

Fixes firedrakeproject/firedrake#1835.