### PR TITLE
Pin decorator

### DIFF
--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -4,4 +4,4 @@ pytest>=2.3
 flake8>=2.1.0
 pycparser>=2.10
 mpi4py>=1.3.1
-decorator
+decorator<=4.4.2


### PR DESCRIPTION
Decorator version 5 changes the API in ways that break the
argument type checking in PyOP2. We're therefore pinning on the
version that works.