### PR TITLE
(DO NOT MERGE) Fix conflicting code generation results

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -3415,7 +3415,7 @@ class JITModule(Cached):
     def _cache_key(cls, kernel, iterset, *args, **kwargs):
         counter = itertools.count()
         seen = defaultdict(lambda: next(counter))
-        key = ((id(dup_comm(iterset.comm)), ) + kernel._wrapper_cache_key_ + iterset._wrapper_cache_key_
+        key = (() + kernel._wrapper_cache_key_ + iterset._wrapper_cache_key_
                + (iterset._extruded, (iterset._extruded and iterset.constant_layers), isinstance(iterset, Subset)))
 
         for arg in args:


### PR DESCRIPTION
This change fixes (at least for me) the `CompilationError "Generated code differs across ranks"` error that is getting thrown by `tests/multigrid/test_poisson_gmg_extruded_serendipity.py`.

I have absolutely no idea why this works. We shouldn't have modified anything to do with the communicators.