### PR TITLE
WIP: Add a non-forking compiler option

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -165,8 +165,9 @@ class ForkingCompiler(Compiler, ABC):
 
     compiler_versions = {}
 
-    _cc = None
-    _cxx = None
+    _cc = "mpicc"
+    _cxx = "mpicxx"
+
     _cppflags = None
     _ldflags = None
 
@@ -412,8 +413,6 @@ Compile errors in %s""" % (e.cmd, e.returncode, logfile, errfile))
 class MacClangCompiler(ForkingCompiler):
     """A compiler for building a shared library on mac systems."""
     
-    _cc = "clang"
-    _cxx = "clang++"
     _cppflags = ["-fPIC", "-Wall", "-framework", "Accelerate"]
     _ldflags = ["-dynamiclib"]
 
@@ -427,8 +426,6 @@ class MacClangCompiler(ForkingCompiler):
 class LinuxGnuCompiler(ForkingCompiler):
     """A compiler for building a shared library on Linux systems."""
 
-    _cc = "gcc"
-    _cxx = "g++"
     _cppflags = ["-fPIC", "-Wall"]
     _ldflags = ["-shared"]
 
@@ -442,8 +439,6 @@ class LinuxGnuCompiler(ForkingCompiler):
 class LinuxIntelCompiler(ForkingCompiler):
     """The Intel compiler for building a shared library on Linux systems."""
 
-    _cc = "icc"
-    _cxx = "icpc"
     _cppflags = ["-fPIC", "-no-multibyte-chars"]
     _ldflags = ["-shared"]
 
@@ -455,9 +450,22 @@ class LinuxIntelCompiler(ForkingCompiler):
 
 
 class NonForkingCompiler(Compiler):
+    ...
+
+
+class DragonFFICompiler(NonForkingCompiler):
+    def compile(self, jitmodule, _):
+        try:
+            import pydffi
+        except ImportError:
+            raise ImportError("DragonFFI must be installed first")
+        ffi = pydffi.FFI()
+        ffi.compile(jitmodule.codetocompile)
+
+
+class TinyCCompiler(NonForkingCompiler):
     def compile(self, jitmodule, _):
         ...
-
 
 
 @collective
@@ -502,11 +510,11 @@ def load(jitmodule, extension, fn_name, cppargs=[], ldargs=[],
         if compiler == 'icc':
             compiler = LinuxIntelCompiler(cppargs, ldargs, cpp=cpp, comm=comm)
         elif compiler == 'gcc':
-            compiler = LinuxCompiler(cppargs, ldargs, cpp=cpp, comm=comm)
+            compiler = LinuxGnuCompiler(cppargs, ldargs, cpp=cpp, comm=comm)
         else:
             raise CompilationError("Unrecognized compiler name '%s'" % compiler)
     elif platform.find('darwin') == 0:
-        compiler = MacCompiler(cppargs, ldargs, cpp=cpp, comm=comm)
+        compiler = MacClangCompiler(cppargs, ldargs, cpp=cpp, comm=comm)
     else:
         raise CompilationError("Don't know what compiler to use for platform '%s'" %
                                platform)

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -156,7 +156,25 @@ def compilation_comm(comm):
 
 class Compiler(ABC):
 
+    @abstractmethod
+    def compile(self, jitmodule, extension):
+        ...
+
+
+class ForkingCompiler(Compiler, ABC):
+
     compiler_versions = {}
+
+    _cc = None
+    _cxx = None
+    _cppflags = None
+    _ldflags = None
+
+    _cflags = None
+    _cxxflags = None
+
+    _optflags = None
+    _debugflags = None
 
     """A compiler for shared libraries.
 
@@ -200,7 +218,7 @@ class Compiler(ABC):
         except KeyError:
             cppflags = self._cppflags + self._extra_cppflags
 
-            if self._debug:
+            if not self._debug:
                 cppflags += self._debugflags
             else:
                 cppflags += self._optflags
@@ -221,42 +239,6 @@ class Compiler(ABC):
 
     @property
     def bugfix_cflags(self):
-        return []
-
-    @property
-    @abstractmethod
-    def _cc(self):
-        ...
-
-    @property
-    @abstractmethod
-    def _cxx(self):
-        ...
-
-    @property
-    @abstractmethod
-    def _optflags(self):
-        ...
-
-    @property
-    def _debugflags(self):
-        return ["-O0", "-g"]
-
-    @property
-    @abstractmethod
-    def _cppflags(self):
-        ...
-
-    @property
-    def _cflags(self):
-        return ["-std=c99"]
-
-    @property
-    def _cxxflags(self):
-        return []
-
-    @property
-    def _ldflags(self):
         return []
 
     @property
@@ -427,76 +409,55 @@ Compile errors in %s""" % (e.cmd, e.returncode, logfile, errfile))
             return ctypes.CDLL(soname)
 
 
-class MacClangCompiler(Compiler):
+class MacClangCompiler(ForkingCompiler):
     """A compiler for building a shared library on mac systems."""
+    
+    _cc = "clang"
+    _cxx = "clang++"
+    _cppflags = ["-fPIC", "-Wall", "-framework", "Accelerate"]
+    _ldflags = ["-dynamiclib"]
 
-    @property
-    def _cc(self):
-        return "clang"
+    _cflags = ["-std=c99"]
+    _cxxflags = []
 
-    @property
-    def _cxx(self):
-        return "clang++"
-
-    @property
-    def _cppflags(self):
-        return ["-fPIC", "-Wall", "-framework", "Accelerate"]
-
-    @property
-    def _optflags(self):
-        return ["-march=native", "-O3", "-ffast-math"]
-
-    @property
-    def _ldflags(self):
-        return ["-dynamiclib"]
+    _optflags = ["-march=native", "-O3", "-ffast-math"]
+    _debugflags = ["-O0", "-g"]
 
 
-class LinuxGnuCompiler(Compiler):
+class LinuxGnuCompiler(ForkingCompiler):
     """A compiler for building a shared library on Linux systems."""
 
-    @property
-    def _cc(self):
-        return "gcc"
+    _cc = "gcc"
+    _cxx = "g++"
+    _cppflags = ["-fPIC", "-Wall"]
+    _ldflags = ["-shared"]
 
-    @property
-    def _cxx(self):
-        return "g++"
+    _cflags = ["-std=c99"]
+    _cxxflags = []
 
-    @property
-    def _cppflags(self):
-        return ["-fPIC", "-Wall"]
-
-    @property
-    def _ldargs(self):
-        return ["-shared"]
-
-    @property
-    def _optflags(self):
-        return ["-march=native", "-O3", "-ffast-math"]
+    _optflags = ["-march=native", "-O3", "-ffast-math"]
+    _debugflags = ["-O0", "-g"]
 
 
-class LinuxIntelCompiler(Compiler):
+class LinuxIntelCompiler(ForkingCompiler):
     """The Intel compiler for building a shared library on Linux systems."""
 
-    @property
-    def _cc(self):
-        return "icc"
+    _cc = "icc"
+    _cxx = "icpc"
+    _cppflags = ["-fPIC", "-no-multibyte-chars"]
+    _ldflags = ["-shared"]
 
-    @property
-    def _cxx(self):
-        return "icpc"
+    _cflags = ["-std=c99"]
+    _cxxflags = []
 
-    @property
-    def _cppflags(self):
-        return ["-fPIC", "-no-multibyte-chars"]
+    _optflags = ["-Ofast", "-xHost"]
+    _debugflags = ["-O0", "-g"]
 
-    @property
-    def _optflags(self):
-        return ["-Ofast", "-xHost"]
 
-    @property
-    def _ldflags(self):
-        return ["-shared"]
+class NonForkingCompiler(Compiler):
+    def compile(self, jitmodule, _):
+        ...
+
 
 
 @collective

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -77,11 +77,8 @@ class Configuration(dict):
     """
     # name, env variable, type, default, write once
     DEFAULTS = {
-        "compiler": ("PYOP2_BACKEND_COMPILER", str, "gcc"),
         "simd_width": ("PYOP2_SIMD_WIDTH", int, 4),
         "debug": ("PYOP2_DEBUG", bool, False),
-        "cflags": ("PYOP2_CFLAGS", str, ""),
-        "ldflags": ("PYOP2_LDFLAGS", str, ""),
         "compute_kernel_flops": ("PYOP2_COMPUTE_KERNEL_FLOPS", bool, False),
         "use_safe_cflags": ("PYOP2_USE_SAFE_CFLAGS", bool, True),
         "type_check": ("PYOP2_TYPE_CHECK", bool, True),


### PR DESCRIPTION
This PR:

- Refactors `compilation.py`
- Adds a new non-forking compiler class so we can compile on systems where the MPI does not allow forking a subprocess

I've fiddled with the environment variables a bit too. For example it now uses `PYOP2_CC` to determine the compiler instead of `CC` and I've moved `PYOP2_CFLAGS` and `PYOP2_LDFLAGS` out of `configuration.py` because they made little sense there.