### PR TITLE
Make PETSc and petsc4py for CI use Firedrake not pip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CC: mpicc
-      PETSC_CONFIGURE_OPTIONS: --with-debugging=1
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      PETSC_DIR: ${{ github.workspace }}/petsc
+      PETSC_ARCH: default
+      PETSC_CONFIGURE_OPTIONS: --with-debugging=1 --with-shared-libraries=1
 
+    steps:
       - name: Install system dependencies
         shell: bash
         run: |
@@ -32,23 +32,50 @@ jobs:
         with:
           python-version: '3.6'
 
-      # xargs is used to force installation of requirements in the order we specified.
-      # pip 20.2 needed for loopy install to work.
-      - name: Install Python dependencies
-        shell: bash
-        run: |
-          pip install pip==20.2
-          xargs -l1 pip install < requirements-ext.txt
-          xargs -l1 pip install < requirements-git.txt
-          pip install pulp
-          pip install -U flake8
+      - name: Clone PETSc
+        uses: actions/checkout@v2
+        with:
+          repository: firedrakeproject/petsc
+          path: ${{ env.PETSC_DIR }}
 
+      - name: Build and install PETSc
+        shell: bash
+        working-directory: ${{ env.PETSC_DIR }}
+        run: |
+          ./configure ${PETSC_CONFIGURE_OPTIONS}
+          make
+
+      - name: Build and install petsc4py
+        shell: bash
+        working-directory: ${{ env.PETSC_DIR }}/src/binding/petsc4py
+        run: |
+          python -m pip install --upgrade cython numpy
+          python -m pip install --no-deps .
+
+      - name: Checkout PyOP2
+        uses: actions/checkout@v2
+        with:
+          path: PyOP2
+      
       - name: Install PyOP2
         shell: bash
-        run: pip install -e .
-
-      - name: Do tests
-        shell: bash
+        working-directory: PyOP2
         run: |
-          make lint
-          py.test test -v --tb=native
+          python -m pip install pip==20.2  # pip 20.2 needed for loopy install to work.
+          
+          # xargs is used to force installation of requirements in the order we specified.
+          xargs -l1 python -m pip install < requirements-ext.txt
+          xargs -l1 python -m pip install < requirements-git.txt
+          python -m pip install pulp
+          python -m pip install -U flake8
+          python -m pip install .
+
+      - name: Run linting
+        shell: bash
+        working-directory: PyOP2
+        run: make lint
+
+      - name: Run tests
+        shell: bash
+        working-directory: PyOP2
+        run: pytest test -v --tb=native

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -4,4 +4,4 @@ pytest>=2.3
 flake8>=2.1.0
 pycparser>=2.10
 mpi4py>=1.3.1
-decorator
+decorator<=4.4.2

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,4 +1,2 @@
-git+https://github.com/firedrakeproject/petsc.git@firedrake#egg=petsc
---no-deps git+https://github.com/firedrakeproject/petsc4py.git@firedrake#egg=petsc4py
 git+https://github.com/coneoproject/COFFEE.git#egg=coffee
 git+https://github.com/firedrakeproject/loopy.git@firedrake#egg=loopy

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -785,11 +785,11 @@ class TestDatAPI:
         assert d.dataset.cdim == 1
 
     def test_dat_dtype_type(self, dset):
-        "The type of a Dat's dtype property should by numpy.dtype."
+        "The type of a Dat's dtype property should be a numpy.dtype."
         d = op2.Dat(dset)
-        assert type(d.dtype) == np.dtype
+        assert isinstance(d.dtype, np.dtype)
         d = op2.Dat(dset, [1.0] * dset.size * dset.cdim)
-        assert type(d.dtype) == np.dtype
+        assert isinstance(d.dtype, np.dtype)
 
     def test_dat_split(self, dat):
         "Splitting a Dat should yield a tuple with self"


### PR DESCRIPTION
This worked on my fork. I've also included some fixes from the `loopy-sprint` branch as these were not Loopy specific and would make our tests fail.

See also: #616