### PR TITLE
Permuted maps

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -2623,6 +2623,41 @@ class Map(object):
         return self == o
 
 
+class PermutedMap(Map):
+    """Composition of a standard :class:`Map` with a constant permutation.
+
+    :arg map_: The map to permute.
+    :arg permutation: The permutation of the map indices.
+
+    Where normally staging to element data is performed as
+
+    .. code-block::
+
+       local[i] = global[map[i]]
+
+    With a :class:`PermutedMap` we instead get
+
+    .. code-block::
+
+       local[i] = global[map[permutation[i]]]
+
+    This might be useful if your local kernel wants data in a
+    different order to the one that the map provides, and you don't
+    want two global-sized data structures.
+    """
+    def __init__(self, map_, permutation):
+        self.map_ = map_
+        self.permutation = np.asarray(permutation, dtype=Map.dtype)
+        assert (np.unique(permutation) == np.arange(map_.arity, dtype=Map.dtype)).all()
+
+    @cached_property
+    def _wrapper_cache_key_(self):
+        return super()._wrapper_cache_key_ + (tuple(self.permutation),)
+
+    def __getattr__(self, name):
+        return getattr(self.map_, name)
+
+
 class MixedMap(Map, ObjectCached):
     r"""A container for a bag of :class:`Map`\s."""
 

--- a/pyop2/codegen/builder.py
+++ b/pyop2/codegen/builder.py
@@ -51,7 +51,7 @@ class Map(object):
         shape = (None, ) + map_.shape[1:]
         values = Argument(shape, dtype=map_.dtype, pfx="map")
         if isinstance(map_, PermutedMap):
-            self.permutation = NamedLiteral(map_.permutation, name=values.name + "_permutation")
+            self.permutation = NamedLiteral(map_.permutation, parent=values, suffix="permutation")
             if offset is not None:
                 offset = offset[map_.permutation]
         else:
@@ -60,7 +60,7 @@ class Map(object):
             if len(set(map_.offset)) == 1:
                 offset = Literal(offset[0], casting=True)
             else:
-                offset = NamedLiteral(offset, name=values.name + "_offset")
+                offset = NamedLiteral(offset, parent=values, suffix="offset")
 
         self.values = values
         self.offset = offset

--- a/pyop2/codegen/builder.py
+++ b/pyop2/codegen/builder.py
@@ -16,7 +16,7 @@ from pyop2.codegen.representation import (Accumulate, Argument, Comparison,
                                           When, Zero)
 from pyop2.datatypes import IntType
 from pyop2.op2 import (ALL, INC, MAX, MIN, ON_BOTTOM, ON_INTERIOR_FACETS,
-                       ON_TOP, READ, RW, WRITE, Subset)
+                       ON_TOP, READ, RW, WRITE, Subset, PermutedMap)
 from pyop2.utils import cached_property
 
 
@@ -30,7 +30,7 @@ class Map(object):
 
     __slots__ = ("values", "offset", "interior_horizontal",
                  "variable", "unroll", "layer_bounds",
-                 "prefetch")
+                 "prefetch", "permutation")
 
     def __init__(self, map_, interior_horizontal, layer_bounds,
                  values=None, offset=None, unroll=False):
@@ -50,6 +50,12 @@ class Map(object):
         offset = map_.offset
         shape = (None, ) + map_.shape[1:]
         values = Argument(shape, dtype=map_.dtype, pfx="map")
+        if isinstance(map_, PermutedMap):
+            self.permutation = NamedLiteral(map_.permutation, name=values.name + "_permutation")
+            if offset is not None:
+                offset = offset[map_.permutation]
+        else:
+            self.permutation = None
         if offset is not None:
             if len(set(map_.offset)) == 1:
                 offset = Literal(offset[0], casting=True)
@@ -76,7 +82,10 @@ class Map(object):
             base_key = None
             if base_key not in self.prefetch:
                 j = Index()
-                base = Indexed(self.values, (n, j))
+                if self.permutation is None:
+                    base = Indexed(self.values, (n, j))
+                else:
+                    base = Indexed(self.values, (n, Indexed(self.permutation, (j,))))
                 self.prefetch[base_key] = Materialise(PackInst(), base, MultiIndex(j))
 
             base = self.prefetch[base_key]
@@ -103,7 +112,10 @@ class Map(object):
             return Indexed(self.prefetch[key], (f, i)), (f, i)
         else:
             assert f.extent == 1 or f.extent is None
-            base = Indexed(self.values, (n, i))
+            if self.permutation is None:
+                base = Indexed(self.values, (n, i))
+            else:
+                base = Indexed(self.values, (n, Indexed(self.permutation, (i,))))
             return base, (f, i)
 
     def indexed_vector(self, n, shape, layer=None):

--- a/pyop2/op2.py
+++ b/pyop2/op2.py
@@ -43,7 +43,7 @@ from pyop2.sequential import par_loop, Kernel  # noqa: F401
 from pyop2.sequential import READ, WRITE, RW, INC, MIN, MAX  # noqa: F401
 from pyop2.base import ON_BOTTOM, ON_TOP, ON_INTERIOR_FACETS, ALL  # noqa: F401
 from pyop2.sequential import Set, ExtrudedSet, MixedSet, Subset, DataSet, MixedDataSet  # noqa: F401
-from pyop2.sequential import Map, MixedMap, Sparsity, Halo  # noqa: F401
+from pyop2.sequential import Map, MixedMap, PermutedMap, Sparsity, Halo  # noqa: F401
 from pyop2.sequential import Global, GlobalDataSet        # noqa: F401
 from pyop2.sequential import Dat, MixedDat, DatView, Mat  # noqa: F401
 from pyop2.sequential import ParLoop as SeqParLoop
@@ -59,7 +59,7 @@ __all__ = ['configuration', 'READ', 'WRITE', 'RW', 'INC', 'MIN', 'MAX',
            'MixedSet', 'Subset', 'DataSet', 'GlobalDataSet', 'MixedDataSet',
            'Halo', 'Dat', 'MixedDat', 'Mat', 'Global', 'Map', 'MixedMap',
            'Sparsity', 'par_loop', 'ParLoop',
-           'DatView']
+           'DatView', 'PermutedMap']
 
 
 def ParLoop(kernel, *args, **kwargs):

--- a/pyop2/sequential.py
+++ b/pyop2/sequential.py
@@ -45,7 +45,7 @@ from pyop2 import petsc_base
 from pyop2.base import par_loop                          # noqa: F401
 from pyop2.base import READ, WRITE, RW, INC, MIN, MAX    # noqa: F401
 from pyop2.base import ALL
-from pyop2.base import Map, MixedMap, Sparsity, Halo      # noqa: F401
+from pyop2.base import Map, MixedMap, PermutedMap, Sparsity, Halo  # noqa: F401
 from pyop2.base import Set, ExtrudedSet, MixedSet, Subset  # noqa: F401
 from pyop2.base import DatView                           # noqa: F401
 from pyop2.base import Kernel                            # noqa: F401

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -809,7 +809,7 @@ class TestDatAPI:
     def test_dat_int(self, dset):
         "Data type for int data should be numpy.int."
         d = op2.Dat(dset, [1] * dset.size * dset.cdim)
-        assert d.dtype == np.int
+        assert d.dtype == np.asarray(1).dtype
 
     def test_dat_convert_int_float(self, dset):
         "Explicit float type should override NumPy's default choice of int."
@@ -909,7 +909,7 @@ class TestMixedDatAPI:
     def test_mixed_dat_illegal_dtype(self, set):
         """Constructing a MixedDat from Dats of different dtype should fail."""
         with pytest.raises(exceptions.DataValueError):
-            op2.MixedDat((op2.Dat(set, dtype=np.int), op2.Dat(set)))
+            op2.MixedDat((op2.Dat(set, dtype=np.int32), op2.Dat(set, dtype=np.float64)))
 
     def test_mixed_dat_dats(self, dats):
         """Constructing a MixedDat from an iterable of Dats should leave them
@@ -1303,22 +1303,22 @@ class TestGlobalAPI:
     def test_global_float(self):
         "Data type for float data should be numpy.float64."
         g = op2.Global(1, 1.0)
-        assert g.dtype == np.double
+        assert g.dtype == np.asarray(1.0).dtype
 
     def test_global_int(self):
         "Data type for int data should be numpy.int."
         g = op2.Global(1, 1)
-        assert g.dtype == np.int
+        assert g.dtype == np.asarray(1).dtype
 
     def test_global_convert_int_float(self):
         "Explicit float type should override NumPy's default choice of int."
-        g = op2.Global(1, 1, 'double')
+        g = op2.Global(1, 1, dtype=np.float64)
         assert g.dtype == np.float64
 
     def test_global_convert_float_int(self):
         "Explicit int type should override NumPy's default choice of float."
-        g = op2.Global(1, 1.5, 'int')
-        assert g.dtype == np.int
+        g = op2.Global(1, 1.5, dtype=np.int64)
+        assert g.dtype == np.int64
 
     def test_global_illegal_dtype(self):
         "Illegal data type should raise DataValueError."

--- a/test/unit/test_caching.py
+++ b/test/unit/test_caching.py
@@ -34,7 +34,6 @@
 
 import pytest
 import numpy
-import random
 from pyop2 import op2, base
 
 from coffee.base import *
@@ -99,15 +98,13 @@ def y(dindset):
 
 @pytest.fixture
 def iter2ind1(iterset, indset):
-    u_map = numpy.array(list(range(nelems)), dtype=numpy.uint32)
-    random.shuffle(u_map, _seed)
+    u_map = numpy.array(list(range(nelems)), dtype=numpy.uint32)[::-1]
     return op2.Map(iterset, indset, 1, u_map, "iter2ind1")
 
 
 @pytest.fixture
 def iter2ind2(iterset, indset):
-    u_map = numpy.array(list(range(nelems)) * 2, dtype=numpy.uint32)
-    random.shuffle(u_map, _seed)
+    u_map = numpy.array(list(range(nelems)) * 2, dtype=numpy.uint32)[::-1]
     return op2.Map(iterset, indset, 2, u_map, "iter2ind2")
 
 

--- a/test/unit/test_callables.py
+++ b/test/unit/test_callables.py
@@ -75,7 +75,7 @@ class TestCallables:
         loopy.set_caching_enabled(False)
 
         k = loopy.make_kernel(
-            ["{[i,j] : 0 <= i,j < 2}"],
+            ["{ : }"],
             """
             B[:,:] = inverse(A[:,:])
             """,
@@ -99,7 +99,7 @@ class TestCallables:
         loopy.set_caching_enabled(False)
 
         k = loopy.make_kernel(
-            ["{[i,j] : 0 <= i,j < 2}"],
+            ["{ : }"],
             """
             x[:] = solve(A[:,:], b[:])
             """,

--- a/test/unit/test_extrusion.py
+++ b/test/unit/test_extrusion.py
@@ -50,7 +50,7 @@ def compute_ind_extr(nums,
                      map,
                      lsize):
     count = 0
-    ind = numpy.zeros(lsize, dtype=numpy.int)
+    ind = numpy.zeros(lsize, dtype=numpy.int32)
     len1 = len(mesh2d)
     for mm in range(lins):
         offset = 0

--- a/test/unit/test_indirect_loop.py
+++ b/test/unit/test_indirect_loop.py
@@ -34,7 +34,6 @@
 
 import pytest
 import numpy as np
-import random
 
 from pyop2 import op2
 from pyop2.exceptions import MapValueError
@@ -81,8 +80,7 @@ def x2(indset):
 @pytest.fixture
 def mapd():
     mapd = list(range(nelems))
-    random.shuffle(mapd, lambda: 0.02041724)
-    return mapd
+    return mapd[::-1]
 
 
 @pytest.fixture

--- a/test/unit/test_subset.py
+++ b/test/unit/test_subset.py
@@ -57,7 +57,7 @@ class TestSubSet:
 
     def test_direct_loop(self, iterset):
         """Test a direct ParLoop on a subset"""
-        indices = np.array([i for i in range(nelems) if not i % 2], dtype=np.int)
+        indices = np.array([i for i in range(nelems) if not i % 2], dtype=np.int32)
         ss = op2.Subset(iterset, indices)
 
         d = op2.Dat(iterset ** 1, data=None, dtype=np.uint32)
@@ -77,8 +77,8 @@ class TestSubSet:
 
     def test_direct_complementary_subsets(self, iterset):
         """Test direct par_loop over two complementary subsets"""
-        even = np.array([i for i in range(nelems) if not i % 2], dtype=np.int)
-        odd = np.array([i for i in range(nelems) if i % 2], dtype=np.int)
+        even = np.array([i for i in range(nelems) if not i % 2], dtype=np.int32)
+        odd = np.array([i for i in range(nelems) if i % 2], dtype=np.int32)
 
         sseven = op2.Subset(iterset, even)
         ssodd = op2.Subset(iterset, odd)
@@ -91,8 +91,8 @@ class TestSubSet:
 
     def test_direct_complementary_subsets_with_indexing(self, iterset):
         """Test direct par_loop over two complementary subsets"""
-        even = np.arange(0, nelems, 2, dtype=np.int)
-        odd = np.arange(1, nelems, 2, dtype=np.int)
+        even = np.arange(0, nelems, 2, dtype=np.int32)
+        odd = np.arange(1, nelems, 2, dtype=np.int32)
 
         sseven = iterset(even)
         ssodd = iterset(odd)
@@ -104,16 +104,16 @@ class TestSubSet:
         assert (d.data == 1).all()
 
     def test_direct_loop_sub_subset(self, iterset):
-        indices = np.arange(0, nelems, 2, dtype=np.int)
+        indices = np.arange(0, nelems, 2, dtype=np.int32)
         ss = op2.Subset(iterset, indices)
-        indices = np.arange(0, nelems//2, 2, dtype=np.int)
+        indices = np.arange(0, nelems//2, 2, dtype=np.int32)
         sss = op2.Subset(ss, indices)
 
         d = op2.Dat(iterset ** 1, data=None, dtype=np.uint32)
         k = op2.Kernel("static void inc(unsigned int* v) { *v += 1; }", "inc")
         op2.par_loop(k, sss, d(op2.RW))
 
-        indices = np.arange(0, nelems, 4, dtype=np.int)
+        indices = np.arange(0, nelems, 4, dtype=np.int32)
         ss2 = op2.Subset(iterset, indices)
         d2 = op2.Dat(iterset ** 1, data=None, dtype=np.uint32)
         op2.par_loop(k, ss2, d2(op2.RW))
@@ -121,16 +121,16 @@ class TestSubSet:
         assert (d.data == d2.data).all()
 
     def test_direct_loop_sub_subset_with_indexing(self, iterset):
-        indices = np.arange(0, nelems, 2, dtype=np.int)
+        indices = np.arange(0, nelems, 2, dtype=np.int32)
         ss = iterset(indices)
-        indices = np.arange(0, nelems//2, 2, dtype=np.int)
+        indices = np.arange(0, nelems//2, 2, dtype=np.int32)
         sss = ss(indices)
 
         d = op2.Dat(iterset ** 1, data=None, dtype=np.uint32)
         k = op2.Kernel("static void inc(unsigned int* v) { *v += 1; }", "inc")
         op2.par_loop(k, sss, d(op2.RW))
 
-        indices = np.arange(0, nelems, 4, dtype=np.int)
+        indices = np.arange(0, nelems, 4, dtype=np.int32)
         ss2 = iterset(indices)
         d2 = op2.Dat(iterset ** 1, data=None, dtype=np.uint32)
         op2.par_loop(k, ss2, d2(op2.RW))
@@ -139,7 +139,7 @@ class TestSubSet:
 
     def test_indirect_loop(self, iterset):
         """Test a indirect ParLoop on a subset"""
-        indices = np.array([i for i in range(nelems) if not i % 2], dtype=np.int)
+        indices = np.array([i for i in range(nelems) if not i % 2], dtype=np.int32)
         ss = op2.Subset(iterset, indices)
 
         indset = op2.Set(2, "indset")
@@ -167,7 +167,7 @@ class TestSubSet:
 
     def test_indirect_loop_with_direct_dat(self, iterset):
         """Test a indirect ParLoop on a subset"""
-        indices = np.array([i for i in range(nelems) if not i % 2], dtype=np.int)
+        indices = np.array([i for i in range(nelems) if not i % 2], dtype=np.int32)
         ss = op2.Subset(iterset, indices)
 
         indset = op2.Set(2, "indset")
@@ -185,8 +185,8 @@ class TestSubSet:
 
     def test_complementary_subsets(self, iterset):
         """Test par_loop on two complementary subsets"""
-        even = np.array([i for i in range(nelems) if not i % 2], dtype=np.int)
-        odd = np.array([i for i in range(nelems) if i % 2], dtype=np.int)
+        even = np.array([i for i in range(nelems) if not i % 2], dtype=np.int32)
+        odd = np.array([i for i in range(nelems) if i % 2], dtype=np.int32)
 
         sseven = op2.Subset(iterset, even)
         ssodd = op2.Subset(iterset, odd)
@@ -216,7 +216,7 @@ static void inc(unsigned int* v1, unsigned int* v2) {
         ss10 = op2.Subset(iterset, [1, 0])
         indset = op2.Set(4)
 
-        dat = op2.Dat(idset ** 1, data=[0, 1], dtype=np.float)
+        dat = op2.Dat(idset ** 1, data=[0, 1], dtype=np.float64)
         map = op2.Map(iterset, indset, 4, [0, 1, 2, 3, 0, 1, 2, 3])
         idmap = op2.Map(iterset, idset, 1, [0, 1])
         sparsity = op2.Sparsity((indset, indset), (map, map))


### PR DESCRIPTION
Add an API for specifying `map o permutation` for some constant permutation of the map order. This is convenient in some cases where one wants to write local kernels that need a different ordering to the FIAT one (say).