### PR TITLE
Shortcut dat copy

### DIFF
--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1772,7 +1772,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
             if isinstance(other, Number):
                 self.data[:] += other
             else:
-                self.data[:] += other.data_ro
+                np.add(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
         return self
 
     def __isub__(self, other):
@@ -1782,7 +1782,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
             if isinstance(other, Number):
                 self.data[:] -= other
             else:
-                self.data[:] -= other.data_ro
+                np.subtract(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
         return self
 
     def __imul__(self, other):
@@ -1791,7 +1791,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
         if isinstance(other, Number):
             self.data[:] *= other
         else:
-            self.data[:] *= other.data_ro
+            np.multiply(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
         return self
 
     def __itruediv__(self, other):
@@ -1800,7 +1800,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
         if isinstance(other, Number):
             self.data[:] /= other
         else:
-            self.data[:] /= other.data_ro
+            np.true_divide(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
         return self
 
     __idiv__ = __itruediv__  # Python 2 compatibility

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1624,7 +1624,6 @@ class Dat(DataCarrier, _EmptyDataMixin):
             self.data[:] = 0
         else:
             self.data[subset.indices] = 0
-        return self
 
     @collective
     def copy(self, other, subset=None):
@@ -1856,8 +1855,6 @@ class Dat(DataCarrier, _EmptyDataMixin):
             self._check_shape(other)
             np.true_divide(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
         return self
-
-    __idiv__ = __itruediv__  # Python 2 compatibility
 
     @collective
     def global_to_local_begin(self, access_mode):

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1580,7 +1580,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
         if other is self:
             return
         if subset is None:
-            other.data[:] = self.data_ro 
+            other.data[:] = self.data_ro
         else:
             other.data[subset.indices] = self.data_ro[subset.indices]
         self._copy_parloop(other, subset=subset).compute()

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1767,14 +1767,22 @@ class Dat(DataCarrier, _EmptyDataMixin):
 
     def __iadd__(self, other):
         """Pointwise addition of fields."""
+        from numbers import Number
         if other is not None:
-            self.data[:] += other.data_ro
+            if isinstance(other, Number):
+                self.data[:] -= other
+            else:
+                self.data[:] += other.data_ro
         return self
 
     def __isub__(self, other):
         """Pointwise subtraction of fields."""
+        from numbers import Number
         if other is not None:
-            self.data[:] -= other.data_ro
+            if isinstance(other, Number):
+                self.data[:] -= other
+            else:
+                self.data[:] -= other.data_ro
         return self
 
     def __imul__(self, other):

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1772,7 +1772,8 @@ class Dat(DataCarrier, _EmptyDataMixin):
             if isinstance(other, Number):
                 self.data[:] += other
             else:
-                np.add(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
+                self._check_shape(other)
+                self.data[:] += other.data_ro
         return self
 
     def __isub__(self, other):
@@ -1782,7 +1783,8 @@ class Dat(DataCarrier, _EmptyDataMixin):
             if isinstance(other, Number):
                 self.data[:] -= other
             else:
-                np.subtract(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
+                self._check_shape(other)
+                self.data[:] -= other.data_ro
         return self
 
     def __imul__(self, other):
@@ -1791,7 +1793,8 @@ class Dat(DataCarrier, _EmptyDataMixin):
         if isinstance(other, Number):
             self.data[:] *= other
         else:
-            np.multiply(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
+            self._check_shape(other)
+            self.data[:] *= other.data_ro
         return self
 
     def __itruediv__(self, other):
@@ -1800,7 +1803,8 @@ class Dat(DataCarrier, _EmptyDataMixin):
         if isinstance(other, Number):
             self.data[:] /= other
         else:
-            np.true_divide(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
+            self._check_shape(other)
+            self.data[:] /= other.data_ro
         return self
 
     __idiv__ = __itruediv__  # Python 2 compatibility

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -816,6 +816,13 @@ class Subset(ExtrudedSet):
         return self._indices
 
     @cached_property
+    def owned_indices(self):
+        """Return the indices that correspond to the owned entities of the
+        superset.
+        """
+        return self.indices[self.indices < self.superset.size]
+
+    @cached_property
     def layers_array(self):
         if self._superset.constant_layers:
             return self._superset.layers_array
@@ -1623,7 +1630,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
         if subset is None:
             self.data[:] = 0
         else:
-            self.data[subset.indices] = 0
+            self.data[subset.owned_indices] = 0
 
     @collective
     def copy(self, other, subset=None):
@@ -1631,12 +1638,13 @@ class Dat(DataCarrier, _EmptyDataMixin):
 
         :arg other: The destination :class:`Dat`
         :arg subset: A :class:`Subset` of elements to copy (optional)"""
+        # breakpoint()
         if other is self:
             return
         if subset is None:
             other.data[:] = self.data_ro
         else:
-            other.data[subset.indices] = self.data_ro[subset.indices]
+            other.data[subset.owned_indices] = self.data_ro[subset.owned_indices]
 
     def __iter__(self):
         """Yield self when iterated over."""

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1627,8 +1627,10 @@ class Dat(DataCarrier, _EmptyDataMixin):
         """Zero the data associated with this :class:`Dat`
 
         :arg subset: A :class:`Subset` of entries to zero (optional)."""
+        # If there is no subset we can safely zero the halo values.
         if subset is None:
-            self.data[:] = 0
+            self._data[:] = 0
+            self.halo_valid = True
         elif subset.superset != self.dataset.set:
             raise MapValueError("The subset and dataset are incompatible")
         else:
@@ -1643,7 +1645,12 @@ class Dat(DataCarrier, _EmptyDataMixin):
         if other is self:
             return
         if subset is None:
-            other.data[:] = self.data_ro
+            # If the current halo is valid we can also copy these values across.
+            if self.halo_valid:
+                other._data[:] = self._data
+                other.halo_valid = True
+            else:
+                other.data[:] = self.data_ro
         elif subset.superset != self.dataset.set:
             raise MapValueError("The subset and dataset are incompatible")
         else:

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1583,28 +1583,6 @@ class Dat(DataCarrier, _EmptyDataMixin):
             other.data[:] = self.data_ro
         else:
             other.data[subset.indices] = self.data_ro[subset.indices]
-        self._copy_parloop(other, subset=subset).compute()
-
-    @collective
-    def _copy_parloop(self, other, subset=None):
-        """Create the :class:`ParLoop` implementing copy."""
-        if not hasattr(self, '_copy_kernel'):
-            import islpy as isl
-            import pymbolic.primitives as p
-            inames = isl.make_zero_and_vars(["i"])
-            domain = (inames[0].le_set(inames["i"])) & (inames["i"].lt_set(inames[0] + self.cdim))
-            _other = p.Variable("other")
-            _self = p.Variable("self")
-            i = p.Variable("i")
-            insn = loopy.Assignment(_other.index(i), _self.index(i), within_inames=frozenset(["i"]))
-            data = [loopy.GlobalArg("self", dtype=self.dtype, shape=(self.cdim,)),
-                    loopy.GlobalArg("other", dtype=other.dtype, shape=(other.cdim,))]
-            knl = loopy.make_function([domain], [insn], data, name="copy", target=loopy.CTarget(), lang_version=(2018, 2))
-
-            self._copy_kernel = _make_object('Kernel', knl, 'copy')
-        return _make_object('ParLoop', self._copy_kernel,
-                            subset or self.dataset.set,
-                            self(READ), other(WRITE))
 
     def __iter__(self):
         """Yield self when iterated over."""

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1770,7 +1770,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
         from numbers import Number
         if other is not None:
             if isinstance(other, Number):
-                self.data[:] -= other
+                self.data[:] += other
             else:
                 self.data[:] += other.data_ro
         return self

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1823,7 +1823,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
                 self.data[:] += other
             else:
                 self._check_shape(other)
-                self.data[:] += other.data_ro
+                np.add(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
         return self
 
     def __isub__(self, other):
@@ -1834,7 +1834,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
                 self.data[:] -= other
             else:
                 self._check_shape(other)
-                self.data[:] -= other.data_ro
+                np.subtract(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
         return self
 
     def __imul__(self, other):
@@ -1844,7 +1844,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
             self.data[:] *= other
         else:
             self._check_shape(other)
-            self.data[:] *= other.data_ro
+            np.multiply(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
         return self
 
     def __itruediv__(self, other):
@@ -1854,7 +1854,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
             self.data[:] /= other
         else:
             self._check_shape(other)
-            self.data[:] /= other.data_ro
+            np.true_divide(self.data[:], other.data_ro, out=self.data[:], casting="unsafe")
         return self
 
     __idiv__ = __itruediv__  # Python 2 compatibility

--- a/pyop2/base.py
+++ b/pyop2/base.py
@@ -1580,7 +1580,7 @@ class Dat(DataCarrier, _EmptyDataMixin):
         if other is self:
             return
         if subset is None:
-            other.data[:] = self.data_ro
+            other.data[:] = self.data_ro 
         else:
             other.data[subset.indices] = self.data_ro[subset.indices]
         self._copy_parloop(other, subset=subset).compute()


### PR DESCRIPTION
Currently dat copying creates a par loop. This is slow and can dominate runtime on a small adjoint problem. In fact, numpy knows how to copy numpy arrays very quickly, so in the simplest case we should just do this.

This could possibly also be extended to the case where there is a subset.