### PR TITLE
Fix pyop2-clean

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -501,29 +501,27 @@ def clear_cache(prompt=False):
     :arg prompt: if ``True`` prompt before removing any files
     """
     cachedir = configuration['cache_dir']
+
     if not os.path.exists(cachedir):
+        print("Cache directory could not be found")
         return
-
-    dirs = [os.path.join(cachedir, dir_) for dir_ in os.listdir(cachedir)]
-    ndirs = len(dirs)
-
-    if ndirs == 0:
+    if len(os.listdir(cachedir)) == 0:
         print("No cached libraries to remove")
         return
 
     remove = True
     if prompt:
-        user = input("Remove %d cached libraries from %s? [Y/n]: " % (ndirs, cachedir))
+        user = input(f"Remove cached libraries from {cachedir}? [Y/n]: ")
 
         while user.lower() not in ['', 'y', 'n']:
             print("Please answer y or n.")
-            user = input("Remove %d cached libraries from %s? [Y/n]: " % (ndirs, cachedir))
+            user = input(f"Remove cached libraries from {cachedir}? [Y/n]: ")
 
         if user.lower() == 'n':
             remove = False
 
     if remove:
-        print("Removing %d cached libraries from %s" % (ndirs, cachedir))
-        [shutil.rmtree(dir_) for dir_ in dirs]
+        print(f"Removing cached libraries from {cachedir}")
+        shutil.rmtree(cachedir)
     else:
         print("Not removing cached libraries")

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -33,6 +33,7 @@
 
 
 import os
+import shutil
 import subprocess
 import sys
 import ctypes
@@ -503,28 +504,26 @@ def clear_cache(prompt=False):
     if not os.path.exists(cachedir):
         return
 
-    files = [os.path.join(cachedir, f) for f in os.listdir(cachedir)
-             if os.path.isfile(os.path.join(cachedir, f))]
-    nfiles = len(files)
+    dirs = [os.path.join(cachedir, dir_) for dir_ in os.listdir(cachedir)]
+    ndirs = len(dirs)
 
-    if nfiles == 0:
+    if ndirs == 0:
         print("No cached libraries to remove")
         return
 
     remove = True
     if prompt:
-
-        user = input("Remove %d cached libraries from %s? [Y/n]: " % (nfiles, cachedir))
+        user = input("Remove %d cached libraries from %s? [Y/n]: " % (ndirs, cachedir))
 
         while user.lower() not in ['', 'y', 'n']:
             print("Please answer y or n.")
-            user = input("Remove %d cached libraries from %s? [Y/n]: " % (nfiles, cachedir))
+            user = input("Remove %d cached libraries from %s? [Y/n]: " % (ndirs, cachedir))
 
         if user.lower() == 'n':
             remove = False
 
     if remove:
-        print("Removing %d cached libraries from %s" % (nfiles, cachedir))
-        [os.remove(f) for f in files]
+        print("Removing %d cached libraries from %s" % (ndirs, cachedir))
+        [shutil.rmtree(dir_) for dir_ in dirs]
     else:
         print("Not removing cached libraries")


### PR DESCRIPTION
The existing solution did not work because we now cache our code in subdirectories (e.g. `2a/c2da0fe98e483fea7fa17cb352c822_p194525.c `).