### PR TITLE
Call apt update in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Install system dependencies
         shell: bash
         run: |
+          sudo apt update
           sudo apt install build-essential mpich libmpich-dev \
               libblas-dev liblapack-dev gfortran
 


### PR DESCRIPTION
I think this should hopefully resolve the occasional CI failures. It's mentioned [here](https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners) and also just seems like common sense.