### PR TITLE
Add disk_cached and cached decorators

### DIFF
--- a/pyop2/mpi.py
+++ b/pyop2/mpi.py
@@ -230,6 +230,13 @@ def free_comms():
         MPI.Comm.Free_keyval(kv)
 
 
+def hash_comm(comm):
+    """Return a hashable identifier for a communicator."""
+    # dup_comm returns a persistent internal communicator so we can
+    # use its id() as the hash since this is stable between invocations.
+    return id(dup_comm(comm))
+
+
 def collective(fn):
     extra = trim("""
     This function is logically collective over MPI ranks, it is an

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -6,3 +6,4 @@ pycparser>=2.10
 mpi4py>=1.3.1
 decorator<=4.4.2
 dataclasses
+cachetools


### PR DESCRIPTION
As part of my quest to cache anything and everything in Firedrake I have added two new caching decorators to PyOP2:
- `@cached` which does in-memory caching only (I've stolen this directly from `cachetools`).
- `@disk_cached` which does in-memory and disk caching. I've largely stolen this from [Firedrake](https://github.com/firedrakeproject/firedrake/blob/master/firedrake/tsfc_interface.py#L73) but wrapped it up in a decorator.