### PR TITLE
PyOP2 Logging: add PETSc events into the linear algebra callables.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         shell: bash
         working-directory: ${{ env.PETSC_DIR }}
         run: |
+          git fetch origin
+          git checkout connorjward/petsc4py-addlogisactive
           ./configure ${PETSC_CONFIGURE_OPTIONS}
           make
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,6 @@ jobs:
         shell: bash
         working-directory: ${{ env.PETSC_DIR }}
         run: |
-          git fetch origin
-          git checkout connorjward/petsc4py-addlogisactive
           ./configure ${PETSC_CONFIGURE_OPTIONS}
           make
 

--- a/pyop2/codegen/c/inverse.c
+++ b/pyop2/codegen/c/inverse.c
@@ -1,6 +1,5 @@
 #include <petscsys.h>
 #include <petscblaslapack.h>
-#include <petsclog.h>
 
 #ifndef PYOP2_WORK_ARRAYS
 #define PYOP2_WORK_ARRAYS
@@ -9,33 +8,34 @@ static PetscBLASInt ipiv_buffer[BUF_SIZE];
 static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
 #endif
 
+#ifndef PYOP2_INV_LOG_EVENTS
+#define PYOP2_INV_LOG_EVENTS
+static PetscLogEvent USER_EVENT_inv_memcpy;
+static PetscLogEvent USER_EVENT_inv_getrf;
+static PetscLogEvent USER_EVENT_inv_getri;
+#endif
+
 static void inverse(PetscScalar* __restrict__ Aout, const PetscScalar* __restrict__ A, PetscBLASInt N)
 {
-    PetscLogEvent  USER_EVENT_memcpy;
-    PetscLogEvent  USER_EVENT_getrf;
-    PetscLogEvent  USER_EVENT_getri;
-    PetscClassId   classid;
+    PetscLogEventRegister("PyOP2InverseCallable_memcpy",PETSC_OBJECT_CLASSID,&USER_EVENT_inv_memcpy);
+    PetscLogEventRegister("PyOP2InverseCallable_getrf",PETSC_OBJECT_CLASSID,&USER_EVENT_inv_getrf);
+    PetscLogEventRegister("PyOP2InverseCallable_getri",PETSC_OBJECT_CLASSID,&USER_EVENT_inv_getri);
 
-    PetscClassIdRegister("PyOP2InverseCallable",&classid);
-    PetscLogEventRegister("PyOP2InverseCallable_memcpy",classid,&USER_EVENT_memcpy);
-    PetscLogEventRegister("PyOP2InverseCallable_getrf",classid,&USER_EVENT_getrf);
-    PetscLogEventRegister("PyOP2InverseCallable_getri",classid,&USER_EVENT_getri);
-
-    PetscLogEventBegin(USER_EVENT_memcpy,0,0,0,0);
+    PetscLogEventBegin(USER_EVENT_inv_memcpy,0,0,0,0);
     PetscBLASInt info;
     PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));
     PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N*N*sizeof(*Awork));
     memcpy(Aout, A, N*N*sizeof(PetscScalar));
-    PetscLogEventEnd(USER_EVENT_memcpy,0,0,0,0);
+    PetscLogEventEnd(USER_EVENT_inv_memcpy,0,0,0,0);
 
-    PetscLogEventBegin(USER_EVENT_getrf,0,0,0,0);
+    PetscLogEventBegin(USER_EVENT_inv_getrf,0,0,0,0);
     LAPACKgetrf_(&N, &N, Aout, &N, ipiv, &info);
-    PetscLogEventEnd(USER_EVENT_getrf,0,0,0,0);
+    PetscLogEventEnd(USER_EVENT_inv_getrf,0,0,0,0);
 
     if(info == 0){
-        PetscLogEventBegin(USER_EVENT_getri,0,0,0,0);
+        PetscLogEventBegin(USER_EVENT_inv_getri,0,0,0,0);
         LAPACKgetri_(&N, Aout, &N, ipiv, Awork, &N, &info);
-        PetscLogEventEnd(USER_EVENT_getri,0,0,0,0);
+        PetscLogEventEnd(USER_EVENT_inv_getri,0,0,0,0);
     }
 
     if(info != 0){

--- a/pyop2/codegen/c/inverse.c
+++ b/pyop2/codegen/c/inverse.c
@@ -1,5 +1,6 @@
 #include <petscsys.h>
 #include <petscblaslapack.h>
+#include <petsclog.h>
 
 #ifndef PYOP2_WORK_ARRAYS
 #define PYOP2_WORK_ARRAYS
@@ -10,14 +11,33 @@ static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
 
 static void inverse(PetscScalar* __restrict__ Aout, const PetscScalar* __restrict__ A, PetscBLASInt N)
 {
+    PetscLogEvent  USER_EVENT_memcpy;
+    PetscLogEvent  USER_EVENT_getrf;
+    PetscLogEvent  USER_EVENT_getri;
+    PetscClassId   classid;
+
+    PetscClassIdRegister("PyOP2InverseCallable",&classid);
+    PetscLogEventRegister("PyOP2InverseCallable_memcpy",classid,&USER_EVENT_memcpy);
+    PetscLogEventRegister("PyOP2InverseCallable_getrf",classid,&USER_EVENT_getrf);
+    PetscLogEventRegister("PyOP2InverseCallable_getri",classid,&USER_EVENT_getri);
+
+    PetscLogEventBegin(USER_EVENT_memcpy,0,0,0,0);
     PetscBLASInt info;
     PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));
     PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N*N*sizeof(*Awork));
     memcpy(Aout, A, N*N*sizeof(PetscScalar));
+    PetscLogEventEnd(USER_EVENT_memcpy,0,0,0,0);
+
+    PetscLogEventBegin(USER_EVENT_getrf,0,0,0,0);
     LAPACKgetrf_(&N, &N, Aout, &N, ipiv, &info);
+    PetscLogEventEnd(USER_EVENT_getrf,0,0,0,0);
+
     if(info == 0){
+        PetscLogEventBegin(USER_EVENT_getri,0,0,0,0);
         LAPACKgetri_(&N, Aout, &N, ipiv, Awork, &N, &info);
+        PetscLogEventEnd(USER_EVENT_getri,0,0,0,0);
     }
+
     if(info != 0){
         fprintf(stderr, "Getri throws nonzero info.");
         abort();

--- a/pyop2/codegen/c/inverse.c
+++ b/pyop2/codegen/c/inverse.c
@@ -10,9 +10,9 @@ static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
 
 #ifndef PYOP2_INV_LOG_EVENTS
 #define PYOP2_INV_LOG_EVENTS
-static PetscLogEvent USER_EVENT_inv_memcpy;
-static PetscLogEvent USER_EVENT_inv_getrf;
-static PetscLogEvent USER_EVENT_inv_getri;
+PetscLogEvent USER_EVENT_inv_memcpy = -1;
+PetscLogEvent USER_EVENT_inv_getrf = -1;
+PetscLogEvent USER_EVENT_inv_getri = -1;
 #endif
 
 #ifndef BEGIN_LOG
@@ -33,14 +33,8 @@ static void endLog(PetscLogEvent eventId){
 }
 #endif
 
-static void inverse(PetscScalar* __restrict__ Aout, const PetscScalar* __restrict__ A, PetscBLASInt N)
+void inverse(PetscScalar* __restrict__ Aout, const PetscScalar* __restrict__ A, PetscBLASInt N)
 {
-    #ifdef PYOP2_PROFILING_ENABLED
-    PetscLogEventRegister("PyOP2InverseCallable_memcpy",PETSC_OBJECT_CLASSID,&USER_EVENT_inv_memcpy);
-    PetscLogEventRegister("PyOP2InverseCallable_getrf",PETSC_OBJECT_CLASSID,&USER_EVENT_inv_getrf);
-    PetscLogEventRegister("PyOP2InverseCallable_getri",PETSC_OBJECT_CLASSID,&USER_EVENT_inv_getri);
-    #endif
-
     beginLog(USER_EVENT_inv_memcpy);
     PetscBLASInt info;
     PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));

--- a/pyop2/codegen/c/solve.c
+++ b/pyop2/codegen/c/solve.c
@@ -1,6 +1,5 @@
 #include <petscsys.h>
 #include <petscblaslapack.h>
-#include <petsclog.h>
 
 #ifndef PYOP2_WORK_ARRAYS
 #define PYOP2_WORK_ARRAYS
@@ -9,36 +8,37 @@ static PetscBLASInt ipiv_buffer[BUF_SIZE];
 static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
 #endif
 
+#ifndef PYOP2_SOLVE_LOG_EVENTS
+#define PYOP2_SOLVE_LOG_EVENTS
+static PetscLogEvent USER_EVENT_solve_memcpy;
+static PetscLogEvent USER_EVENT_solve_getrf;
+static PetscLogEvent USER_EVENT_solve_getrs;
+#endif
+
 static void solve(PetscScalar* __restrict__ out, const PetscScalar* __restrict__ A, const PetscScalar* __restrict__ B, PetscBLASInt N)
 {
-    PetscLogEvent  USER_EVENT_memcpy;
-    PetscLogEvent  USER_EVENT_getrf;
-    PetscLogEvent  USER_EVENT_getrs;
-    PetscClassId   classid;
+    PetscLogEventRegister("PyOP2SolveCallable_memcpy",PETSC_OBJECT_CLASSID,&USER_EVENT_solve_memcpy);
+    PetscLogEventRegister("PyOP2SolveCallable_getrf",PETSC_OBJECT_CLASSID,&USER_EVENT_solve_getrf);
+    PetscLogEventRegister("PyOP2SolveCallable_getrs",PETSC_OBJECT_CLASSID,&USER_EVENT_solve_getrs);
 
-    PetscClassIdRegister("PyOP2SolveCallable",&classid);
-    PetscLogEventRegister("PyOP2SolveCallable_memcpy",classid,&USER_EVENT_memcpy);
-    PetscLogEventRegister("PyOP2SolveCallable_getrf",classid,&USER_EVENT_getrf);
-    PetscLogEventRegister("PyOP2SolveCallable_gerts",classid,&USER_EVENT_getrs);
-
-    PetscLogEventBegin(USER_EVENT_memcpy,0,0,0,0);
+    PetscLogEventBegin(USER_EVENT_solve_memcpy,0,0,0,0);
     PetscBLASInt info;
     PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));
     memcpy(out,B,N*sizeof(PetscScalar));
     PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N*N*sizeof(*Awork));
     memcpy(Awork,A,N*N*sizeof(PetscScalar));
-    PetscLogEventEnd(USER_EVENT_memcpy,0,0,0,0);
+    PetscLogEventEnd(USER_EVENT_solve_memcpy,0,0,0,0);
 
     PetscBLASInt NRHS = 1;
     const char T = 'T';
-    PetscLogEventBegin(USER_EVENT_getrf,0,0,0,0);
+    PetscLogEventBegin(USER_EVENT_solve_getrf,0,0,0,0);
     LAPACKgetrf_(&N, &N, Awork, &N, ipiv, &info);
-    PetscLogEventEnd(USER_EVENT_getrf,0,0,0,0);
+    PetscLogEventEnd(USER_EVENT_solve_getrf,0,0,0,0);
 
     if(info == 0){
-        PetscLogEventBegin(USER_EVENT_getrs,0,0,0,0);
+        PetscLogEventBegin(USER_EVENT_solve_getrs,0,0,0,0);
         LAPACKgetrs_(&T, &N, &NRHS, Awork, &N, ipiv, out, &N, &info);
-        PetscLogEventEnd(USER_EVENT_getrs,0,0,0,0);
+        PetscLogEventEnd(USER_EVENT_solve_getrs,0,0,0,0);
     }
 
     if(info != 0){

--- a/pyop2/codegen/c/solve.c
+++ b/pyop2/codegen/c/solve.c
@@ -10,9 +10,9 @@ static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
 
 #ifndef PYOP2_SOLVE_LOG_EVENTS
 #define PYOP2_SOLVE_LOG_EVENTS
-static PetscLogEvent USER_EVENT_solve_memcpy;
-static PetscLogEvent USER_EVENT_solve_getrf;
-static PetscLogEvent USER_EVENT_solve_getrs;
+PetscLogEvent USER_EVENT_solve_memcpy = -1;
+PetscLogEvent USER_EVENT_solve_getrf = -1;
+PetscLogEvent USER_EVENT_solve_getrs = -1;
 #endif
 
 #ifndef BEGIN_LOG
@@ -33,14 +33,8 @@ static void endLog(PetscLogEvent eventId){
 }
 #endif
 
-static void solve(PetscScalar* __restrict__ out, const PetscScalar* __restrict__ A, const PetscScalar* __restrict__ B, PetscBLASInt N)
+void solve(PetscScalar* __restrict__ out, const PetscScalar* __restrict__ A, const PetscScalar* __restrict__ B, PetscBLASInt N)
 {
-    #ifdef PYOP2_PROFILING_ENABLED
-    PetscLogEventRegister("PyOP2SolveCallable_memcpy",PETSC_OBJECT_CLASSID,&USER_EVENT_solve_memcpy);
-    PetscLogEventRegister("PyOP2SolveCallable_getrf",PETSC_OBJECT_CLASSID,&USER_EVENT_solve_getrf);
-    PetscLogEventRegister("PyOP2SolveCallable_getrs",PETSC_OBJECT_CLASSID,&USER_EVENT_solve_getrs);
-    #endif
-
     beginLog(USER_EVENT_solve_memcpy);
     PetscBLASInt info;
     PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));

--- a/pyop2/codegen/c/solve.c
+++ b/pyop2/codegen/c/solve.c
@@ -1,5 +1,6 @@
 #include <petscsys.h>
 #include <petscblaslapack.h>
+#include <petsclog.h>
 
 #ifndef PYOP2_WORK_ARRAYS
 #define PYOP2_WORK_ARRAYS
@@ -10,17 +11,36 @@ static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
 
 static void solve(PetscScalar* __restrict__ out, const PetscScalar* __restrict__ A, const PetscScalar* __restrict__ B, PetscBLASInt N)
 {
+    PetscLogEvent  USER_EVENT_memcpy;
+    PetscLogEvent  USER_EVENT_getrf;
+    PetscLogEvent  USER_EVENT_getrs;
+    PetscClassId   classid;
+
+    PetscClassIdRegister("PyOP2SolveCallable",&classid);
+    PetscLogEventRegister("PyOP2SolveCallable_memcpy",classid,&USER_EVENT_memcpy);
+    PetscLogEventRegister("PyOP2SolveCallable_getrf",classid,&USER_EVENT_getrf);
+    PetscLogEventRegister("PyOP2SolveCallable_gerts",classid,&USER_EVENT_getrs);
+
+    PetscLogEventBegin(USER_EVENT_memcpy,0,0,0,0);
     PetscBLASInt info;
     PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));
     memcpy(out,B,N*sizeof(PetscScalar));
     PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N*N*sizeof(*Awork));
     memcpy(Awork,A,N*N*sizeof(PetscScalar));
+    PetscLogEventEnd(USER_EVENT_memcpy,0,0,0,0);
+
     PetscBLASInt NRHS = 1;
     const char T = 'T';
+    PetscLogEventBegin(USER_EVENT_getrf,0,0,0,0);
     LAPACKgetrf_(&N, &N, Awork, &N, ipiv, &info);
+    PetscLogEventEnd(USER_EVENT_getrf,0,0,0,0);
+
     if(info == 0){
+        PetscLogEventBegin(USER_EVENT_getrs,0,0,0,0);
         LAPACKgetrs_(&T, &N, &NRHS, Awork, &N, ipiv, out, &N, &info);
+        PetscLogEventEnd(USER_EVENT_getrs,0,0,0,0);
     }
+
     if(info != 0){
         fprintf(stderr, "Gesv throws nonzero info.");
         abort();

--- a/pyop2/codegen/c/solve.c
+++ b/pyop2/codegen/c/solve.c
@@ -15,30 +15,50 @@ static PetscLogEvent USER_EVENT_solve_getrf;
 static PetscLogEvent USER_EVENT_solve_getrs;
 #endif
 
+#ifndef BEGIN_LOG
+#define BEGIN_LOG
+static void beginLog(PetscLogEvent eventId){
+    #ifdef PYOP2_PROFILING_ENABLED
+    PetscLogEventBegin(eventId,0,0,0,0);
+    #endif
+}
+#endif
+
+#ifndef END_LOG
+#define END_LOG
+static void endLog(PetscLogEvent eventId){
+    #ifdef PYOP2_PROFILING_ENABLED
+    PetscLogEventEnd(eventId,0,0,0,0);
+    #endif
+}
+#endif
+
 static void solve(PetscScalar* __restrict__ out, const PetscScalar* __restrict__ A, const PetscScalar* __restrict__ B, PetscBLASInt N)
 {
+    #ifdef PYOP2_PROFILING_ENABLED
     PetscLogEventRegister("PyOP2SolveCallable_memcpy",PETSC_OBJECT_CLASSID,&USER_EVENT_solve_memcpy);
     PetscLogEventRegister("PyOP2SolveCallable_getrf",PETSC_OBJECT_CLASSID,&USER_EVENT_solve_getrf);
     PetscLogEventRegister("PyOP2SolveCallable_getrs",PETSC_OBJECT_CLASSID,&USER_EVENT_solve_getrs);
+    #endif
 
-    PetscLogEventBegin(USER_EVENT_solve_memcpy,0,0,0,0);
+    beginLog(USER_EVENT_solve_memcpy);
     PetscBLASInt info;
     PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));
     memcpy(out,B,N*sizeof(PetscScalar));
     PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N*N*sizeof(*Awork));
     memcpy(Awork,A,N*N*sizeof(PetscScalar));
-    PetscLogEventEnd(USER_EVENT_solve_memcpy,0,0,0,0);
+    endLog(USER_EVENT_solve_memcpy);
 
     PetscBLASInt NRHS = 1;
     const char T = 'T';
-    PetscLogEventBegin(USER_EVENT_solve_getrf,0,0,0,0);
+    beginLog(USER_EVENT_solve_getrf);
     LAPACKgetrf_(&N, &N, Awork, &N, ipiv, &info);
-    PetscLogEventEnd(USER_EVENT_solve_getrf,0,0,0,0);
+    endLog(USER_EVENT_solve_getrf);
 
     if(info == 0){
-        PetscLogEventBegin(USER_EVENT_solve_getrs,0,0,0,0);
+        beginLog(USER_EVENT_solve_getrs);
         LAPACKgetrs_(&T, &N, &NRHS, Awork, &N, ipiv, out, &N, &info);
-        PetscLogEventEnd(USER_EVENT_solve_getrs,0,0,0,0);
+        endLog(USER_EVENT_solve_getrs);
     }
 
     if(info != 0){

--- a/pyop2/codegen/loopycompat.py
+++ b/pyop2/codegen/loopycompat.py
@@ -106,7 +106,9 @@ def _match_caller_callee_argument_dimension_for_single_kernel(
 
             elif isinstance(callee_insn, (CInstruction,
                     _DataObliviousInstruction)):
-                pass
+                # Matching for c instructions is not ensure
+                # but just dropping them is no option
+                new_callee_insns.append(callee_insn)
             else:
                 raise NotImplementedError("Unknown instruction %s." %
                         type(insn))

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -515,7 +515,7 @@ def _add_profiling_events(dll):
         The event is generated here in python and then set in the shared library,
         so that memory is not allocated over and over again in the C kernel.
     """
-    if PETSc.Log.getActive():
+    if PETSc.Log.isActive():
         if hasattr(dll, "solve"):
             ctypes.c_int.in_dll(dll, 'USER_EVENT_solve_memcpy').value = PETSc.Log.Event("PyOP2SolveCallable_solve_memcpy").id
             ctypes.c_int.in_dll(dll, 'USER_EVENT_solve_getrf').value = PETSc.Log.Event("PyOP2SolveCallable_solve_getrf").id

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -508,6 +508,7 @@ def load(jitmodule, extension, fn_name, cppargs=[], ldargs=[],
     fn.restype = restype
     return fn
 
+
 def _add_profiling_events(dll):
     """
         If PyOP2 is in profiling mode, add events to profile the local linear algebra calls.

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -186,7 +186,7 @@ class Compiler(object):
         self._cppargs = cppargs + configuration['cflags'].split()
         if configuration["use_safe_cflags"]:
             self._cppargs += self.workaround_cflags
-        if PETSc.Log.getActive():
+        if PETSc.Log.isActive():
             self._cppargs += ["-DPYOP2_PROFILING_ENABLED"]
         self._ldargs = ldargs + configuration['ldflags'].split()
 

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -48,6 +48,7 @@ from pyop2.mpi import dup_comm, get_compilation_comm, set_compilation_comm
 from pyop2.configuration import configuration
 from pyop2.logger import debug, progress, INFO
 from pyop2.exceptions import CompilationError
+from petsc4py import PETSc
 
 
 def _check_hashes(x, y, datatype):
@@ -185,6 +186,8 @@ class Compiler(object):
         self._cppargs = cppargs + configuration['cflags'].split()
         if configuration["use_safe_cflags"]:
             self._cppargs += self.workaround_cflags
+        if PETSc.Log.getActive():
+            self._cppargs += ["-DPYOP2_PROFILING_ENABLED"]
         self._ldargs = ldargs + configuration['ldflags'].split()
 
     @property


### PR DESCRIPTION
I added logging into the C kernels for the solve and inverse (which are what Slate solves and inverses are translated to).