### PR TITLE
Fix dtypes for COFFEE local kernel

### DIFF
--- a/pyop2/local_kernel.py
+++ b/pyop2/local_kernel.py
@@ -211,25 +211,22 @@ class CStringLocalKernel(LocalKernel):
     def dtypes(self, dtypes):
         self._dtypes = dtypes
 
-    @cached_property
-    def arguments(self):
-        assert self.dtypes is not None
-
-        return tuple(LocalKernelArg(acc, dtype)
-                     for acc, dtype in zip(self.accesses, self.dtypes))
-
 
 class CoffeeLocalKernel(LocalKernel):
     """:class:`LocalKernel` class where `code` has type :class:`coffee.base.Node`."""
 
     @validate_type(("code", coffee.base.Node, TypeError))
-    def __init__(self, code, *args, **kwargs):
-        super().__init__(code, *args, **kwargs)
+    def __init__(self, code, name, accesses=None, dtypes=None, **kwargs):
+        super().__init__(code, name, accesses, **kwargs)
+        self._dtypes = dtypes
 
     @property
     def dtypes(self):
-        _, fundecl = self.code.children
-        return tuple(a.typ for a in fundecl.args)
+        return self._dtypes
+
+    @dtypes.setter
+    def dtypes(self, dtypes):
+        self._dtypes = dtypes
 
 
 class LoopyLocalKernel(LocalKernel):

--- a/pyop2/parloop.py
+++ b/pyop2/parloop.py
@@ -13,7 +13,7 @@ from pyop2.configuration import configuration
 from pyop2.exceptions import KernelTypeError, MapValueError, SetTypeError
 from pyop2.global_kernel import (GlobalKernelArg, DatKernelArg, MixedDatKernelArg,
                                  MatKernelArg, MixedMatKernelArg, GlobalKernel)
-from pyop2.local_kernel import LocalKernel, CStringLocalKernel
+from pyop2.local_kernel import LocalKernel, CStringLocalKernel, CoffeeLocalKernel
 from pyop2.types import (Access, Global, Dat, DatView, MixedDat, Mat, Set,
                          MixedSet, ExtrudedSet, Subset, Map, MixedMap)
 from pyop2.utils import cached_property
@@ -592,7 +592,7 @@ def LegacyParloop(local_knl, iterset, *args, **kwargs):
 
     # finish building the local kernel
     local_knl.accesses = tuple(a.access for a in args)
-    if isinstance(local_knl, CStringLocalKernel):
+    if isinstance(local_knl, (CStringLocalKernel, CoffeeLocalKernel)):
         local_knl.dtypes = tuple(a.data.dtype for a in args)
 
     global_knl_args = tuple(a.global_kernel_arg for a in args)


### PR DESCRIPTION
It turns out that my method for determining the dtypes for a COFFEE local kernel was not robust so now it is treated the same as a `CStringLocalKernel`.

The reason for the magic that I do here is to enable backwards compatibility. `dtypes` is a property that 'belongs' to the local kernel but previously we would pass it in with the `Arg` objects. This means that the old `op2.Kernel` constructor does not accept this argument and we have to attach it later on.

This needs to get merged to fix Thetis tests ([related PR](https://github.com/thetisproject/thetis/pull/296)).