### PR TITLE
Vectorisation sprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set correct Python version
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Clone PETSc
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set correct Python version
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.6'
 
       - name: Clone PETSc
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set correct Python version
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
 
       - name: Clone PETSc
         uses: actions/checkout@v2

--- a/pyop2/caching.py
+++ b/pyop2/caching.py
@@ -237,7 +237,7 @@ class Cached(object):
     @cached_property
     def cache_key(self):
         """Cache key."""
-        return self._key + tuple(configuration["vectorization_strategy"])
+        return self._key
 
 
 cached = cachetools.cached

--- a/pyop2/caching.py
+++ b/pyop2/caching.py
@@ -237,7 +237,7 @@ class Cached(object):
     @cached_property
     def cache_key(self):
         """Cache key."""
-        return self._key
+        return self._key + tuple(configuration["vectorization_strategy"])
 
 
 cached = cachetools.cached

--- a/pyop2/codegen/c/inverse.c
+++ b/pyop2/codegen/c/inverse.c
@@ -65,8 +65,9 @@ static void inverse(PetscScalar* __restrict__ Aout, const PetscScalar* __restric
         fprintf(stderr, "Getri throws nonzero info.");
         abort();
     }
-    if ( N > BUF_SIZE ) {
+
+    if (Awork != work_buffer)
         free(Awork);
+    if (ipiv != ipiv_buffer)
         free(ipiv);
-    }
 }

--- a/pyop2/codegen/c/inverse.c
+++ b/pyop2/codegen/c/inverse.c
@@ -6,17 +6,38 @@
 #define BUF_SIZE 30
 static PetscBLASInt ipiv_buffer[BUF_SIZE];
 static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
+static PetscScalar Aout_proxy_buffer[BUF_SIZE*BUF_SIZE];
 #endif
 
-static void inverse(PetscScalar* __restrict__ Aout, const PetscScalar* __restrict__ A, PetscBLASInt N)
+static void inverse(PetscScalar* __restrict__ Aout, const PetscScalar* __restrict__ A, PetscBLASInt N,
+                    PetscBLASInt incA, PetscBLASInt incAout)
 {
     PetscBLASInt info;
     PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));
     PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N*N*sizeof(*Awork));
-    memcpy(Aout, A, N*N*sizeof(PetscScalar));
-    LAPACKgetrf_(&N, &N, Aout, &N, ipiv, &info);
+
+    PetscInt N_sq = N * N;
+    PetscInt one = 1;
+
+    // Aout_proxy: 'Aout', but stored contiguously
+    PetscScalar *Aout_proxy;
+    if (incAout == 1)
+      Aout_proxy = Aout;
+    else
+    {
+      // TODO: Must see if allocating has a significant performance impact
+      Aout_proxy = N_sq <= BUF_SIZE ? Aout_proxy_buffer : malloc(N*N*sizeof(*Aout));
+    }
+
+    BLAScopy_(&N_sq, A, &incA, Aout_proxy, &one);
+
+    LAPACKgetrf_(&N, &N, Aout_proxy, &N, ipiv, &info);
     if(info == 0){
-        LAPACKgetri_(&N, Aout, &N, ipiv, Awork, &N, &info);
+        LAPACKgetri_(&N, Aout_proxy, &N, ipiv, Awork, &N, &info);
+
+        // Copy Aout_proxy back to Aout
+        if (Aout != Aout_proxy)
+          BLAScopy_(&N_sq, Aout_proxy, &one, Aout, &incAout);
     }
     if(info != 0){
         fprintf(stderr, "Getri throws nonzero info.");

--- a/pyop2/codegen/c/inverse.c
+++ b/pyop2/codegen/c/inverse.c
@@ -70,4 +70,6 @@ static void inverse(PetscScalar* __restrict__ Aout, const PetscScalar* __restric
         free(Awork);
     if (ipiv != ipiv_buffer)
         free(ipiv);
+    if ((Aout_proxy != Aout) && (Aout_proxy != Aout_proxy_buffer))
+        free(Aout_proxy);
 }

--- a/pyop2/codegen/c/solve.c
+++ b/pyop2/codegen/c/solve.c
@@ -8,6 +8,8 @@ static PetscBLASInt ipiv_buffer[BUF_SIZE];
 static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
 #endif
 
+static PetscScalar out_proxy_buffer[BUF_SIZE];
+
 #ifndef PYOP2_SOLVE_LOG_EVENTS
 #define PYOP2_SOLVE_LOG_EVENTS
 PetscLogEvent ID_solve_memcpy = -1;
@@ -16,15 +18,32 @@ PetscLogEvent ID_solve_getrs = -1;
 static PetscBool log_active_solve = 0;
 #endif
 
-void solve(PetscScalar* __restrict__ out, const PetscScalar* __restrict__ A, const PetscScalar* __restrict__ B, PetscBLASInt N)
+
+/*
+ * @param[incA]: Stride value while accessing elements of 'A'.
+ * @param[incB]: Stride value while accessing elements of 'B'.
+ * @param[incOut]: Stride value while accessing elements of 'out'.
+ */
+void solve(PetscScalar* __restrict__ out, const PetscScalar* __restrict__ A, const PetscScalar* __restrict__ B, PetscBLASInt N,
+           PetscBLASInt incA, PetscBLASInt incB, PetscBLASInt incOut)
 {
+    PetscScalar* out_proxy;  /// output laid-out with unit stride, expected by LAPACK
+    PetscInt N_sq = N*N;
+    PetscInt one = 1;
     PetscLogIsActive(&log_active_solve);
     if (log_active_solve){PetscLogEventBegin(ID_solve_memcpy,0,0,0,0);}
     PetscBLASInt info;
     PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));
-    memcpy(out,B,N*sizeof(PetscScalar));
-    PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N*N*sizeof(*Awork));
-    memcpy(Awork,A,N*N*sizeof(PetscScalar));
+
+    if (incOut == 1)
+      out_proxy = out;
+    else
+      out_proxy = (N <= BUF_SIZE) ? out_proxy_buffer : malloc(N*sizeof(*out));
+
+    BLAScopy_(&N, B, &incB, out_proxy, &one);
+
+    PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N_sq*sizeof(*Awork));
+    BLAScopy_(&N_sq, A, &incA, Awork, &one);
     if (log_active_solve){PetscLogEventEnd(ID_solve_memcpy,0,0,0,0);}
 
     PetscBLASInt NRHS = 1;
@@ -35,7 +54,11 @@ void solve(PetscScalar* __restrict__ out, const PetscScalar* __restrict__ A, con
 
     if(info == 0){
         if (log_active_solve){PetscLogEventBegin(ID_solve_getrs,0,0,0,0);}
-        LAPACKgetrs_(&T, &N, &NRHS, Awork, &N, ipiv, out, &N, &info);
+        LAPACKgetrs_(&T, &N, &NRHS, Awork, &N, ipiv, out_proxy, &N, &info);
+
+        if (out != out_proxy)
+            BLAScopy_(&N, out_proxy, &one, out, &incOut);
+
         if (log_active_solve){PetscLogEventEnd(ID_solve_getrs,0,0,0,0);}
     }
 
@@ -44,8 +67,12 @@ void solve(PetscScalar* __restrict__ out, const PetscScalar* __restrict__ A, con
         abort();
     }
 
-    if ( N > BUF_SIZE ) {
-        free(ipiv);
-        free(Awork);
-    }
+    if (ipiv != ipiv_buffer)
+      free(ipiv);
+
+    if (Awork != work_buffer)
+      free(Awork);
+
+    if (out_proxy != out_proxy_buffer)
+      free(out_proxy);
 }

--- a/pyop2/codegen/c/solve.c
+++ b/pyop2/codegen/c/solve.c
@@ -73,6 +73,6 @@ void solve(PetscScalar* __restrict__ out, const PetscScalar* __restrict__ A, con
     if (Awork != work_buffer)
       free(Awork);
 
-    if (out_proxy != out_proxy_buffer)
+    if ((out_proxy != out) && (out_proxy != out_proxy_buffer))
       free(out_proxy);
 }

--- a/pyop2/codegen/rep2loopy.py
+++ b/pyop2/codegen/rep2loopy.py
@@ -139,6 +139,7 @@ class LACallable(loopy.ScalarCallable, metaclass=abc.ABCMeta):
                 callables_table)
 
     def emit_call_insn(self, insn, target, expression_to_code_mapper):
+        from loopy.codegen import UnvectorizableError
         assert self.is_ready_for_codegen()
         assert isinstance(insn, loopy.CallInstruction)
 
@@ -146,6 +147,9 @@ class LACallable(loopy.ScalarCallable, metaclass=abc.ABCMeta):
 
         parameters = list(parameters)
         par_dtypes = [self.arg_id_to_dtype[i] for i, _ in enumerate(parameters)]
+
+        if expression_to_code_mapper.codegen_state.vectorization_info:
+            raise UnvectorizableError("LACallable: cannot take in vector arrays")
 
         parameters.append(insn.assignees[-1])
         par_dtypes.append(self.arg_id_to_dtype[0])

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -487,7 +487,7 @@ class LinuxGnuCompiler(Compiler):
     _cxxflags = ("-fPIC", "-Wall")
     _ldflags = ("-shared",)
 
-    _optflags = ("-march=native", "-O3", "-ffast-math")
+    _optflags = ("-march=native", "-O3", "-ffast-math","-fopenmp")
     _debugflags = ("-O0", "-g")
 
     def sniff_compiler_version(self, cpp=False):

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -487,7 +487,7 @@ class LinuxGnuCompiler(Compiler):
     _cxxflags = ("-fPIC", "-Wall")
     _ldflags = ("-shared",)
 
-    _optflags = ("-march=native", "-O3", "-ffast-math","-fopenmp")
+    _optflags = ("-march=native", "-O3", "-ffast-math", "-fopenmp")
     _debugflags = ("-O0", "-g")
 
     def sniff_compiler_version(self, cpp=False):

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -544,7 +544,7 @@ class LinuxClangCompiler(Compiler):
     _cxxflags = ("-fPIC", "-Wall")
     _ldflags = ("-shared", "-L/usr/lib")
 
-    _optflags = ("-march=native", "-O3", "-ffast-math")
+    _optflags = ("-march=native", "-O3", "-ffast-math", "-fopenmp-simd")
     _debugflags = ("-O0", "-g")
 
 

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -635,9 +635,9 @@ def load(jitmodule, extension, fn_name, cppargs=(), ldargs=(),
     else:
         # Sniff compiler from executable
         if cpp:
-            exe = configuration["cxx"] or "g++"
+            exe = configuration["cxx"] or "mpicxx"
         else:
-            exe = configuration["cc"] or "gcc"
+            exe = configuration["cc"] or "mpicc"
         compiler = sniff_compiler(exe)
     dll = compiler(cppargs, ldargs, cpp=cpp, comm=comm).get_so(code, extension)
     if isinstance(jitmodule, GlobalKernel):

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -139,6 +139,8 @@ def sniff_compiler(exe):
                 compiler = MacClangARMCompiler
             elif machine == "x86_64":
                 compiler = MacClangCompiler
+        elif name == "GNU":
+            compiler = MacGNUCompiler
         else:
             compiler = AnonymousCompiler
     else:
@@ -469,6 +471,11 @@ class MacClangARMCompiler(MacClangCompiler):
     # seems to be a homebrew configuration issue somewhere. Hopefully this
     # requirement will go away at some point.
     _ldflags = ("-dynamiclib", "-L/opt/homebrew/opt/gcc/lib/gcc/11")
+
+
+class MacGNUCompiler(MacClangCompiler):
+    """A compiler for building a shared library on Mac systems with a GNU compiler."""
+    _name = "Mac GNU"
 
 
 class LinuxGnuCompiler(Compiler):

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -44,16 +44,18 @@ def default_simd_width():
     from cpuinfo import get_cpu_info
     avx_to_width = {'avx': 2, 'avx1': 2, 'avx128': 2, 'avx2': 4,
                     'avx256': 4, 'avx3': 8, 'avx512': 8}
-    longest_ext = [t for t in get_cpu_info()["flags"] if t.startswith('avx')][-1]
-    if longest_ext not in avx_to_width.keys():
-        if longest_ext[:6] not in avx_to_width.keys():
-            assert longest_ext[:4] in avx_to_width.keys(), \
-                "The vector extension of your architecture is unknown. Disable vectorisation!"
-            return avx_to_width[longest_ext[:4]]
-        else:
-            return avx_to_width[longest_ext[:6]]
+    longest_simd_extension = [t for t in get_cpu_info()["flags"] if t.startswith('avx')][-1]
+    if longest_simd_extension in avx_to_width.keys():
+        return avx_to_width[longest_simd_extension]
+    elif longest_simd_extension[:6] in avx_to_width.keys():
+        return avx_to_width[longest_simd_extension[:6]]
+    elif longest_simd_extension[:4] in avx_to_width.keys():
+        return avx_to_width[longest_simd_extension[:4]]
     else:
-        return avx_to_width[longest_ext]
+        raise ConfigurationError(f"The vector extension of your architecture is unknown.\
+                                   Must be one of {str(avx_to_width.keys())}.\
+                                   We advise to disable vectorisation."
+                                 )
 
 
 class Configuration(dict):

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -96,7 +96,7 @@ class Configuration(dict):
     :param alignment: A :class:`int` which specifies a size to which all temporaries
         are aligned in memory.
 
-        - ``sun2020study``: Cross-element vectorization strategy of
+        - ``cross-element``: Cross-element vectorization strategy of
           `<https://doi.org/10.1177/1094342020945005>`__.
     """
     # name, env variable, type, default, write once
@@ -117,7 +117,7 @@ class Configuration(dict):
         "simd_width":
             ("PYOP2_SIMD_WIDTH", int, default_simd_width()),
         "vectorization_strategy":
-            ("PYOP2_VECT_STRATEGY", str, "sun2020study"),
+            ("PYOP2_VECT_STRATEGY", str, "cross-element"),
         "alignment":
             ("PYOP2_ALIGNMENT", int, 64),
         "debug":

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -54,7 +54,8 @@ def default_simd_width():
     else:
         raise ConfigurationError(f"The vector extension of your architecture is unknown.\
                                    Must be one of {str(avx_to_width.keys())}.\
-                                   We advise to disable vectorisation."
+                                   We advise to disable vectorisation \
+                                   with export PYOP2_VECT_STRATEGY=""."
                                  )
 
 
@@ -192,5 +193,7 @@ class Configuration(dict):
 
 
 configuration = Configuration()
+if configuration["vectorization_strategy"]:
+    configuration["simd_width"] = default_simd_width()
 
 target = CWithGNULibcTarget()

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -95,11 +95,10 @@ class Configuration(dict):
     :param vectorization_strategy: A :class:`str` describing the
         vectorization strategy that must to be applied to the kernels. Can
         be one of the following --
-    :param alignment: A :class:`int` which specifies a size to which all temporaries
-        are aligned in memory.
-
         - ``cross-element``: Cross-element vectorization strategy of
           `<https://doi.org/10.1177/1094342020945005>`__.
+    :param alignment: A :class:`int` which specifies a size to which all temporaries
+        are aligned in memory.
     """
     # name, env variable, type, default, write once
     cache_dir = os.path.join(gettempdir(), "pyop2-cache-uid%s" % os.getuid())

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -117,7 +117,7 @@ class Configuration(dict):
         "ldflags":
             ("PYOP2_LDFLAGS", str, ""),
         "simd_width":
-            ("PYOP2_SIMD_WIDTH", int, default_simd_width()),
+            ("PYOP2_SIMD_WIDTH", int, 1),
         "vectorization_strategy":
             ("PYOP2_VECT_STRATEGY", str, "cross-element"),
         "alignment":

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -93,6 +93,8 @@ class Configuration(dict):
     :param vectorization_strategy: A :class:`str` describing the
         vectorization strategy that must to be applied to the kernels. Can
         be one of the following --
+    :param alignment: A :class:`int` which specifies a size to which all temporaries
+        are aligned in memory.
 
         - ``sun2020study``: Cross-element vectorization strategy of
           `<https://doi.org/10.1177/1094342020945005>`__.
@@ -118,8 +120,6 @@ class Configuration(dict):
             ("PYOP2_VECT_STRATEGY", str, "sun2020study"),
         "alignment":
             ("PYOP2_ALIGNMENT", int, 64),
-        "time":
-            ("PYOP2_TIME", bool, False),
         "debug":
             ("PYOP2_DEBUG", bool, False),
         "compute_kernel_flops":

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -90,6 +90,12 @@ class Configuration(dict):
         cdim > 1 be built as block sparsities, or dof sparsities.  The
         former saves memory but changes which preconditioners are
         available for the resulting matrices.  (Default yes)
+    :param vectorization_strategy: A :class:`str` describing the
+        vectorization strategy that must to be applied to the kernels. Can
+        be one of the following --
+
+        - ``sun2020study``: Cross-element vectorization strategy of
+          `<https://doi.org/10.1177/1094342020945005>`__.
     """
     # name, env variable, type, default, write once
     cache_dir = os.path.join(gettempdir(), "pyop2-cache-uid%s" % os.getuid())
@@ -109,7 +115,7 @@ class Configuration(dict):
         "simd_width":
             ("PYOP2_SIMD_WIDTH", int, default_simd_width()),
         "vectorization_strategy":
-            ("PYOP2_VECT_STRATEGY", str, "ve"),
+            ("PYOP2_VECT_STRATEGY", str, "sun2020study"),
         "alignment":
             ("PYOP2_ALIGNMENT", int, 64),
         "time":

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -387,6 +387,7 @@ class GlobalKernel(Cached):
             preamble = "".join(process_preambles(getattr(code, "device_preambles", [])))
             device_code = "\n\n".join(str(dp.ast) for dp in code.device_programs)
             return preamble + "\nextern \"C\" {\n" + device_code + "\n}\n"
+
         return code.device_code()
 
     def vectorise(self, wrapper, iname, batch_size):
@@ -442,7 +443,7 @@ class GlobalKernel(Cached):
                     isinstance(insn, lp.MultiAssignmentBase)
                     and isinstance(insn.expression, prim.Call)
                     and insn.expression.function.name in ["solve", "inverse"]):
-                temps_not_to_vectorize -= (insn.dependency_names())
+                temps_not_to_vectorize |= (insn.dependency_names())
 
         # }}}
 

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -355,7 +355,9 @@ class GlobalKernel(Cached):
         if vectorisable:
             # change target to generate vectorized code via gcc vector
             # extensions
-            wrapper = wrapper.copy(target=lp.CVectorExtensionsTarget())
+            wrapper = wrapper.copy(target=lp.CVectorExtensionsTarget(
+                vec_fallback=lp.VectorizationFallback.OMP_SIMD
+            ))
             # inline all inner kernels
             names = self.local_kernel.code.callables_table
             for name in names:
@@ -487,8 +489,7 @@ class GlobalKernel(Cached):
                 kernel = lp.tag_array_axes(kernel, name, tag)
 
         # tag the inner iname as vectorized
-        kernel = lp.tag_inames(kernel,
-                               {inner_iname: lp.VectorizeTag(lp.OpenMPSIMDTag())})
+        kernel = lp.tag_inames(kernel, {inner_iname: "vec"})
 
         return wrapper.with_kernel(kernel)
 

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -333,11 +333,14 @@ class GlobalKernel(Cached):
         else:
             iname = "n"
 
-        has_matrix = any(isinstance(arg, MatKernelArg) for arg in self.arguments)
+        # TODO: vectorizing 2-form assembly kernels is possible, but must
+        # change the arguments passed to MatSetValuesxxx (not yet implemented)
+        has_matrix = any(isinstance(arg, (MatKernelArg, MixedMatKernelArg))
+                         for arg in self.arguments)
         has_rw = any(arg.access == op2.RW for arg in self.local_kernel.arguments)
         is_cplx = (any(arg.dtype == 'complex128' for arg in self.local_kernel.arguments)
                    or any(arg.dtype.dtype == 'complex128' for arg in tuple(wrapper.default_entrypoint.temporary_variables.values())))
-        vectorisable = (not (has_matrix or has_rw) and (configuration["vectorization_strategy"])) and not is_cplx
+        vectorisable = ((not (has_matrix or has_rw)) and (configuration["vectorization_strategy"])) and not is_cplx
 
         if vectorisable:
             if isinstance(self.local_kernel.code, lp.TranslationUnit):

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -348,11 +348,11 @@ class GlobalKernel(Cached):
                 # change target to generate vectorized code via gcc vector
                 # extensions
                 wrapper = wrapper.copy(target=lp.CVectorExtensionsTarget())
+                # inline all inner kernels 
                 names = self.local_kernel.code.callables_table
                 for name in names:
                     if name in wrapper.callables_table.keys() \
                     and isinstance(wrapper.callables_table[name], lp.CallableKernel):
-                        print(name)
                         wrapper = lp.inline_callable_kernel(wrapper, name)
                 wrapper = self.vectorise(wrapper, iname, configuration["simd_width"])
         code = lp.generate_code_v2(wrapper)

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -344,6 +344,9 @@ class GlobalKernel(Cached):
 
         if vectorisable:
             if isinstance(self.local_kernel.code, lp.TranslationUnit):
+                # change target to generate vectorized code via gcc vector
+                # extensions
+                wrapper = wrapper.copy(target=lp.CVectorExtensionsTarget())
                 wrapper = lp.inline_callable_kernel(wrapper, self.local_kernel.name)
                 wrapper = self.vectorise(wrapper, iname, configuration["simd_width"])
         code = lp.generate_code_v2(wrapper)
@@ -364,7 +367,6 @@ class GlobalKernel(Cached):
         if batch_size == 1:
             return wrapper
 
-        wrapper = wrapper.copy(target=lp.CVectorExtensionsTarget())
         kernel = wrapper.default_entrypoint
 
         # align temps

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -372,7 +372,7 @@ class GlobalKernel(Cached):
             if iname not in get_dependencies(tuple(all_insn_preds)):
                 # https://github.com/inducer/loopy/issues/615
                 # TODO: get rid of this guard once the loopy issue is fixed
-                if configuration["vectorization_strategy"] == "sun2020study":
+                if configuration["vectorization_strategy"] == "cross-element":
                     wrapper = self.vectorise(wrapper, iname,
                                                 configuration["simd_width"])
                 else:

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -435,6 +435,10 @@ class GlobalKernel(Cached):
                                    if (tv.read_only
                                        and tv.initializer is not None)}
 
+        temps_not_to_vectorize |= {name
+                                   for name, tv in kernel.temporary_variables.items()
+                                   if kernel.writer_map().get(tv.name, set()) | kernel.reader_map().get(tv.name, set()) == set()}
+
         # {{{ clang (unlike gcc) does not allow taking address of vector-type
         # variable
 

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -39,7 +39,7 @@ class MapKernelArg:
 
     @property
     def cache_key(self):
-        return type(self), self.arity, self.offset, configuration["vectorization_strategy"]
+        return type(self), self.arity, self.offset
 
 
 @dataclass(eq=False, frozen=True)
@@ -59,7 +59,7 @@ class PermutedMapKernelArg:
 
     @property
     def cache_key(self):
-        return type(self), self.base_map.cache_key, tuple(self.permutation), configuration["vectorization_strategy"]
+        return type(self), self.base_map.cache_key, tuple(self.permutation)
 
 
 @dataclass(frozen=True)
@@ -73,7 +73,7 @@ class GlobalKernelArg:
 
     @property
     def cache_key(self):
-        return type(self), self.dim, configuration["vectorization_strategy"]
+        return type(self), self.dim
 
     @property
     def maps(self):
@@ -112,7 +112,7 @@ class DatKernelArg:
     @property
     def cache_key(self):
         map_key = self.map_.cache_key if self.map_ is not None else None
-        return type(self), self.dim, map_key, self.index, configuration["vectorization_strategy"]
+        return type(self), self.dim, map_key, self.index
 
     @property
     def maps(self):
@@ -141,7 +141,7 @@ class MatKernelArg:
 
     @property
     def cache_key(self):
-        return type(self), self.dims, tuple(m.cache_key for m in self.maps), self.unroll, configuration["vectorization_strategy"]
+        return type(self), self.dims, tuple(m.cache_key for m in self.maps), self.unroll
 
 
 @dataclass(frozen=True)
@@ -161,7 +161,7 @@ class MixedDatKernelArg:
 
     @property
     def cache_key(self):
-        return tuple(a.cache_key for a in self.arguments) + tuple(configuration["vectorization_strategy"])
+        return tuple(a.cache_key for a in self.arguments) 
 
     @property
     def maps(self):
@@ -233,7 +233,8 @@ class GlobalKernel(Cached):
     @classmethod
     def _cache_key(cls, local_knl, arguments, **kwargs):
         key = [cls, local_knl.cache_key,
-               *kwargs.items(), configuration["simd_width"]]
+               *kwargs.items(), configuration["simd_width"],
+               configuration["vectorization_strategy"]]
 
         key.extend([a.cache_key for a in arguments])
 

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -443,8 +443,6 @@ class GlobalKernel(Cached):
                     and isinstance(insn.expression, prim.Call)
                     and insn.expression.function.name in ["solve", "inverse"]):
                 temps_not_to_vectorize -= (insn.dependency_names())
-                print("NO GCC")
-                print((insn.dependency_names()))
 
         # }}}
 

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -391,7 +391,7 @@ class GlobalKernel(Cached):
         kernel = kernel.copy(temporary_variables=tmps)
         shifted_iname = kernel.get_var_name_generator()(f"{iname}_shift")
 
-        # {{{
+        # {{{ record temps that cannot be vectorized
 
         # Do not vectorize temporaries used outside *iname*
         from functools import reduce

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -383,7 +383,6 @@ class GlobalKernel(Cached):
                         "Vectorization strategy"
                         f" '{configuration['vectorization_strategy']}'")
 
-        print(wrapper)
         code = lp.generate_code_v2(wrapper)
 
         if self.local_kernel.cpp:
@@ -415,6 +414,17 @@ class GlobalKernel(Cached):
             wrapper = wrapper.with_kernel(new_entrypoint)
 
         kernel = wrapper.default_entrypoint
+
+        # {{{ get rid of noop insns
+
+        from loopy.match import Id, Or
+
+        noop_insn_ids = [Id(insn.id)
+                         for insn in kernel.instructions
+                         if isinstance(insn, lp.NoOpInstruction)]
+        kernel = lp.remove_instructions(kernel, Or(tuple(noop_insn_ids)))
+
+        # }}}
 
         # align temps
         alignment = configuration["alignment"]

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -403,7 +403,6 @@ class GlobalKernel(Cached):
         tmps = {name: tv.copy(alignment=alignment)
                 for name, tv in kernel.temporary_variables.items()}
         kernel = kernel.copy(temporary_variables=tmps)
-        shifted_iname = kernel.get_var_name_generator()(f"{iname}_shift")
 
         # {{{ record temps that cannot be vectorized
 
@@ -431,7 +430,7 @@ class GlobalKernel(Cached):
         from loopy.symbolic import pw_aff_to_expr
         import pymbolic.primitives as prim
         lbound = pw_aff_to_expr(kernel.get_iname_bounds(iname).lower_bound_pw_aff)
-
+        shifted_iname = kernel.get_var_name_generator()(f"{iname}_shift")
         kernel = lp.affine_map_inames(kernel, iname, shifted_iname,
                                       [(prim.Variable(shifted_iname),
                                        (prim.Variable(iname) - lbound))])
@@ -439,6 +438,7 @@ class GlobalKernel(Cached):
         # }}}
 
         # split iname
+        # note there is no front slab needed because iname is shifted (see above)
         slabs = (0, 1)
         inner_iname = kernel.get_var_name_generator()(f"{shifted_iname}_batch")
 

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -339,7 +339,8 @@ class GlobalKernel(Cached):
 
         has_matrix = any(isinstance(arg, MatKernelArg) for arg in self.arguments)
         has_rw = any(arg.access == op2.RW for arg in self.local_kernel.arguments)
-        is_cplx = any(arg.dtype == 'complex128' for arg in self.local_kernel.arguments)
+        is_cplx = (any(arg.dtype == 'complex128' for arg in self.local_kernel.arguments)
+                   or any(arg.dtype.dtype == 'complex128' for arg in tuple(wrapper.default_entrypoint.temporary_variables.values())))
         vectorisable = (not (has_matrix or has_rw) and (configuration["vectorization_strategy"])) and not is_cplx
 
         if vectorisable:

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -383,7 +383,6 @@ class GlobalKernel(Cached):
                         "Vectorization strategy"
                         f" '{configuration['vectorization_strategy']}'")
 
-        print(wrapper)
         code = lp.generate_code_v2(wrapper)
 
         if self.local_kernel.cpp:

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -367,6 +367,14 @@ class GlobalKernel(Cached):
         if batch_size == 1:
             return wrapper
 
+        if not configuration["debug"]:
+            # loopy warns for every instruction that cannot be vectorized;
+            # ignore in non-debug mode.
+            new_entrypoint = wrapper.default_entrypoint.copy(
+                silenced_warnings=(wrapper.default_entrypoint.silenced_warnings
+                                   + ["vectorize_failed"]))
+            wrapper = wrapper.with_kernel(new_entrypoint)
+
         kernel = wrapper.default_entrypoint
 
         # align temps

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -349,7 +349,7 @@ class GlobalKernel(Cached):
         code = lp.generate_code_v2(wrapper)
 
         if self.local_kernel.cpp:
-            from lp.codegen.result import process_preambles
+            from loopy.codegen.result import process_preambles
             preamble = "".join(process_preambles(getattr(code, "device_preambles", [])))
             device_code = "\n\n".join(str(dp.ast) for dp in code.device_programs)
             return preamble + "\nextern \"C\" {\n" + device_code + "\n}\n"

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -348,11 +348,12 @@ class GlobalKernel(Cached):
                 # change target to generate vectorized code via gcc vector
                 # extensions
                 wrapper = wrapper.copy(target=lp.CVectorExtensionsTarget())
-                # inline all inner kernels 
+                # inline all inner kernels
                 names = self.local_kernel.code.callables_table
                 for name in names:
-                    if name in wrapper.callables_table.keys() \
-                    and isinstance(wrapper.callables_table[name], lp.CallableKernel):
+                    if (name in wrapper.callables_table.keys()
+                            and isinstance(wrapper.callables_table[name],
+                                           lp.CallableKernel)):
                         wrapper = lp.inline_callable_kernel(wrapper, name)
                 wrapper = self.vectorise(wrapper, iname, configuration["simd_width"])
         code = lp.generate_code_v2(wrapper)

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -161,7 +161,7 @@ class MixedDatKernelArg:
 
     @property
     def cache_key(self):
-        return tuple(a.cache_key for a in self.arguments) 
+        return tuple(a.cache_key for a in self.arguments)
 
     @property
     def maps(self):

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -349,7 +349,7 @@ class GlobalKernel(Cached):
                           for arg in tuple(wrapper.default_entrypoint.temporary_variables.values())))  # global temps complex?
         extruded_coords = self.local_kernel.name.endswith("extrusion")  # FIXME is there a better way to know that this kernel generated the extrusion coords?
         is_loopy_kernel = isinstance(self.local_kernel.code, lp.TranslationUnit)
-        vectorisable = is_loopy_kernel and((not (has_matrix or has_rw)) and (configuration["vectorization_strategy"])) and not is_cplx and not extruded_coords
+        vectorisable = is_loopy_kernel and ((not (has_matrix or has_rw)) and (configuration["vectorization_strategy"])) and not is_cplx and not extruded_coords
 
         if vectorisable:
             # change target to generate vectorized code via gcc vector
@@ -359,8 +359,8 @@ class GlobalKernel(Cached):
             names = self.local_kernel.code.callables_table
             for name in names:
                 if (name in wrapper.callables_table.keys()
-                        and isinstance(wrapper.callables_table[name],
-                                        lp.CallableKernel)):
+                    and isinstance(wrapper.callables_table[name],
+                                   lp.CallableKernel)):
                     wrapper = lp.inline_callable_kernel(wrapper, name)
 
             all_insn_preds = reduce(
@@ -374,7 +374,7 @@ class GlobalKernel(Cached):
                 # TODO: get rid of this guard once the loopy issue is fixed
                 if configuration["vectorization_strategy"] == "cross-element":
                     wrapper = self.vectorise(wrapper, iname,
-                                                configuration["simd_width"])
+                                             configuration["simd_width"])
                 else:
                     raise NotImplementedError(
                         "Vectorization strategy"

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -348,7 +348,12 @@ class GlobalKernel(Cached):
                 # change target to generate vectorized code via gcc vector
                 # extensions
                 wrapper = wrapper.copy(target=lp.CVectorExtensionsTarget())
-                wrapper = lp.inline_callable_kernel(wrapper, self.local_kernel.name)
+                names = self.local_kernel.code.callables_table
+                for name in names:
+                    if name in wrapper.callables_table.keys() \
+                    and isinstance(wrapper.callables_table[name], lp.CallableKernel):
+                        print(name)
+                        wrapper = lp.inline_callable_kernel(wrapper, name)
                 wrapper = self.vectorise(wrapper, iname, configuration["simd_width"])
         code = lp.generate_code_v2(wrapper)
 

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -381,7 +381,6 @@ class GlobalKernel(Cached):
                         f" '{configuration['vectorization_strategy']}'")
 
         code = lp.generate_code_v2(wrapper)
-        print(code)
 
         if self.local_kernel.cpp:
             from loopy.codegen.result import process_preambles

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -340,10 +340,10 @@ class GlobalKernel(Cached):
         has_matrix = any(isinstance(arg, (MatKernelArg, MixedMatKernelArg))
                          for arg in self.arguments)
         has_rw = any(arg.access == op2.RW for arg in self.local_kernel.arguments)
-        is_cplx = (any(dtype.is_complex() for dtype in self.local_kernel.dtypes)  # local args complex?
-                   or any(arg.dtype.is_complex() for n in self.local_kernel.code.callables_table
+        is_cplx = (any(dtype.dtype=="complex128" for dtype in self.local_kernel.dtypes)  # local args complex?
+                   or any(arg.dtype.dtype=="complex128" for n in self.local_kernel.code.callables_table
                           for arg in tuple(self.local_kernel.code.callables_table[n].subkernel.temporary_variables.values()))  # local temps complex?
-                   or any(arg.dtype.is_complex()  for arg in tuple(wrapper.default_entrypoint.temporary_variables.values())))  # global temps complex?
+                   or any(arg.dtype.dtype=="complex128" for arg in tuple(wrapper.default_entrypoint.temporary_variables.values())))  # global temps complex?
         extruded_coords = self.local_kernel.name.endswith("extrusion")  # FIXME is there a better way to know that this kernel generated the extrusion coords?
         vectorisable = ((not (has_matrix or has_rw)) and (configuration["vectorization_strategy"])) and not is_cplx and not extruded_coords
 

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -351,7 +351,6 @@ class GlobalKernel(Cached):
         is_loopy_kernel = isinstance(self.local_kernel.code, lp.TranslationUnit)
         vectorisable = is_loopy_kernel and ((not (has_matrix or has_rw)) and (configuration["vectorization_strategy"])) and not is_cplx and not extruded_coords
 
-        print(vectorisable)
         if vectorisable:
             # change target to generate vectorized code via gcc vector
             # extensions

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -343,8 +343,9 @@ class GlobalKernel(Cached):
         vectorisable = (not (has_matrix or has_rw) and (configuration["vectorization_strategy"])) and not is_cplx
 
         if vectorisable:
-            wrapper = lp.inline_callable_kernel(wrapper, self.local_kernel.name)
-            wrapper = self.vectorise(wrapper, iname, configuration["simd_width"])
+            if isinstance(self.local_kernel.code, lp.TranslationUnit):
+                wrapper = lp.inline_callable_kernel(wrapper, self.local_kernel.name)
+                wrapper = self.vectorise(wrapper, iname, configuration["simd_width"])
         code = lp.generate_code_v2(wrapper)
 
         if self.local_kernel.cpp:

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -340,10 +340,8 @@ class GlobalKernel(Cached):
         has_matrix = any(isinstance(arg, (MatKernelArg, MixedMatKernelArg))
                          for arg in self.arguments)
         has_rw = any(arg.access == op2.RW for arg in self.local_kernel.arguments)
-        is_cplx = (any(dtype.dtype=="complex128" for dtype in self.local_kernel.dtypes)  # local args complex?
-                   or any(arg.dtype.dtype=="complex128" for n in self.local_kernel.code.callables_table
-                          for arg in tuple(self.local_kernel.code.callables_table[n].subkernel.temporary_variables.values()))  # local temps complex?
-                   or any(arg.dtype.dtype=="complex128" for arg in tuple(wrapper.default_entrypoint.temporary_variables.values())))  # global temps complex?
+        is_cplx = (any(lp.types.NumpyType(dtype).is_complex() if not isinstance(dtype, lp.types.NumpyType) else dtype for dtype in self.local_kernel.dtypes)  # local args complex?
+                   or any(arg.dtype.is_complex() for arg in tuple(wrapper.default_entrypoint.temporary_variables.values())))  # global temps complex?
         extruded_coords = self.local_kernel.name.endswith("extrusion")  # FIXME is there a better way to know that this kernel generated the extrusion coords?
         vectorisable = ((not (has_matrix or has_rw)) and (configuration["vectorization_strategy"])) and not is_cplx and not extruded_coords
 

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -340,7 +340,8 @@ class GlobalKernel(Cached):
         has_rw = any(arg.access == op2.RW for arg in self.local_kernel.arguments)
         is_cplx = (any(arg.dtype == 'complex128' for arg in self.local_kernel.arguments)
                    or any(arg.dtype.dtype == 'complex128' for arg in tuple(wrapper.default_entrypoint.temporary_variables.values())))
-        vectorisable = ((not (has_matrix or has_rw)) and (configuration["vectorization_strategy"])) and not is_cplx
+        extruded_coords = self.local_kernel.name.endswith("extrusion")  # FIXME is there a better way to know that this kernel generated the extrusion coords?
+        vectorisable = ((not (has_matrix or has_rw)) and (configuration["vectorization_strategy"])) and not is_cplx and not extruded_coords
 
         if vectorisable:
             if isinstance(self.local_kernel.code, lp.TranslationUnit):

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -383,6 +383,7 @@ class GlobalKernel(Cached):
                         "Vectorization strategy"
                         f" '{configuration['vectorization_strategy']}'")
 
+        print(wrapper)
         code = lp.generate_code_v2(wrapper)
 
         if self.local_kernel.cpp:
@@ -501,8 +502,8 @@ class GlobalKernel(Cached):
         kernel = lp.distribute_loops(kernel,
                                      cinsn_match,
                                      outer_inames=outer_inames)
-        inames_to_untag = [kernel.id_to_insn[cinsn_id].within_inames - outer_inames
-                           for cinsn_id in cinsn_ids]
+        inames_to_untag = reduce(set.union, [kernel.id_to_insn[cinsn_id].within_inames - outer_inames
+                           for cinsn_id in cinsn_ids], set())
         for iname_to_untag in inames_to_untag:
             kernel = lp.untag_inames(kernel, iname_to_untag, lp.VectorizeTag)
         kernel = lp.tag_inames(kernel, {iname_to_untag: "unr" for iname_to_untag in inames_to_untag})

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -340,10 +340,10 @@ class GlobalKernel(Cached):
         has_matrix = any(isinstance(arg, (MatKernelArg, MixedMatKernelArg))
                          for arg in self.arguments)
         has_rw = any(arg.access == op2.RW for arg in self.local_kernel.arguments)
-        is_cplx = (any(dtype == 'complex128' for dtype in self.local_kernel.dtypes)  # local args complex?
-                   or any(arg.dtype.dtype == 'complex128' for n in self.local_kernel.code.callables_table
+        is_cplx = (any(dtype.is_complex() for dtype in self.local_kernel.dtypes)  # local args complex?
+                   or any(arg.dtype.is_complex() for n in self.local_kernel.code.callables_table
                           for arg in tuple(self.local_kernel.code.callables_table[n].subkernel.temporary_variables.values()))  # local temps complex?
-                   or any(arg.dtype.dtype == 'complex128' for arg in tuple(wrapper.default_entrypoint.temporary_variables.values())))  # global temps complex?
+                   or any(arg.dtype.is_complex()  for arg in tuple(wrapper.default_entrypoint.temporary_variables.values())))  # global temps complex?
         extruded_coords = self.local_kernel.name.endswith("extrusion")  # FIXME is there a better way to know that this kernel generated the extrusion coords?
         vectorisable = ((not (has_matrix or has_rw)) and (configuration["vectorization_strategy"])) and not is_cplx and not extruded_coords
 

--- a/pyop2/local_kernel.py
+++ b/pyop2/local_kernel.py
@@ -115,7 +115,7 @@ class LocalKernel(abc.ABC):
 
     @property
     def cache_key(self):
-        return self._immutable_cache_key, self.accesses, self.dtypes
+        return self._immutable_cache_key, self.accesses, self.dtypes, configuration["vectorization_strategy"]
 
     @cached_property
     def _immutable_cache_key(self):

--- a/pyop2/local_kernel.py
+++ b/pyop2/local_kernel.py
@@ -115,7 +115,7 @@ class LocalKernel(abc.ABC):
 
     @property
     def cache_key(self):
-        return self._immutable_cache_key, self.accesses, self.dtypes, configuration["vectorization_strategy"]
+        return self._immutable_cache_key, self.accesses, self.dtypes
 
     @cached_property
     def _immutable_cache_key(self):

--- a/pyop2/parloop.py
+++ b/pyop2/parloop.py
@@ -203,9 +203,12 @@ class Parloop:
     def nbytes(self):
         nbytes = 0
         seen = set()
-        for arg in self.arguments:
-            nbytes += arg.data.nbytes
-            for map_ in arg.maps:
+        for lk_arg, gk_arg, pl_arg in self.zipped_arguments:
+            if lk_arg.access == Access.INC:
+                nbytes += pl_arg.data.nbytes * 2
+            else:
+                nbytes += pl_arg.data.nbytes 
+            for map_ in pl_arg.maps:
                 if map_ is None:
                     continue
                 for k in map_._kernel_args_:

--- a/pyop2/parloop.py
+++ b/pyop2/parloop.py
@@ -207,7 +207,7 @@ class Parloop:
             if lk_arg.access == Access.INC:
                 nbytes += pl_arg.data.nbytes * 2
             else:
-                nbytes += pl_arg.data.nbytes 
+                nbytes += pl_arg.data.nbytes
             for map_ in pl_arg.maps:
                 if map_ is None:
                     continue

--- a/test/unit/test_vectorisation.py
+++ b/test/unit/test_vectorisation.py
@@ -1,0 +1,102 @@
+# This file is part of PyOP2
+#
+# PyOP2 is Copyright (c) 2012, Imperial College London and
+# others. Please see the AUTHORS file in the main source directory for
+# a full list of copyright holders.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * The name of Imperial College London or that of other
+#       contributors may not be used to endorse or promote products
+#       derived from this software without specific prior written
+#       permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTERS
+# ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+import numpy as np
+from pyop2 import op2
+from pyop2.configuration import configuration
+import glob
+import os
+import pytest
+
+
+some_vectorisation_keys = ["__attribute__", "vector_size", "aligned", "#pragma omp simd"]
+
+
+class TestVectorisation:
+
+    @pytest.fixture
+    def s(self):
+        return op2.Set(1)
+
+    @pytest.fixture
+    def md1(self, s):
+        n = op2.Dat(s, [3], np.float64)
+        o = op2.Dat(s, [4], np.float64)
+        md = op2.MixedDat([n, o])
+        return md
+
+    @pytest.fixture
+    def md(self, s):
+        n = op2.Dat(s, [4], np.float64)
+        o = op2.Dat(s, [5], np.float64)
+        md = op2.MixedDat([n, o])
+        return md
+
+    def test_vectorisation(self, md1, md):
+        # Test that vectorised code produced the correct result
+        ret = md.inner(md1)
+        assert abs(ret - 32) < 1e-12
+        ret = md1.inner(md)
+        assert abs(ret - 32) < 1e-12
+
+        # Test that we actually vectorised
+        list_of_files = glob.glob(configuration["cache_dir"]+"/*/*.c")
+        latest_file = max(list_of_files, key=os.path.getctime)
+        with open(latest_file, 'r') as file:
+            generated_code = file.read()
+        assert (all(key in generated_code for key in some_vectorisation_keys)), "The kernel for an inner product has not been succesfully vectorised."
+
+    def test_no_vectorisation(self, md1, md):
+        # turn vectorisation off
+        op2.init(**{"vectorization_strategy": ""})
+
+        # Test that unvectorised code produced the correct result
+        ret = md.inner(md1)
+        assert abs(ret - 32) < 1e-12
+        ret = md1.inner(md)
+        assert abs(ret - 32) < 1e-12
+
+        # Test that we did not vectorise
+        print(configuration["cache_dir"])
+        list_of_files = glob.glob(configuration["cache_dir"]+"/*/*.c")
+        print(list_of_files)
+        latest_file = max(list_of_files, key=os.path.getctime)
+        with open(latest_file, 'r') as file:
+            generated_code = file.read()
+        assert not (any(key in generated_code for key in some_vectorisation_keys)), "The kernel for an inner product has not been succesfully vectorised."
+
+        # change vect config back to be turned on by default
+        op2.init(**{"vectorization_strategy": "cross-element"})
+
+
+if __name__ == '__main__':
+    pytest.main(os.path.abspath(__file__))

--- a/test/unit/test_vectorisation.py
+++ b/test/unit/test_vectorisation.py
@@ -86,9 +86,7 @@ class TestVectorisation:
         assert abs(ret - 32) < 1e-12
 
         # Test that we did not vectorise
-        print(configuration["cache_dir"])
         list_of_files = glob.glob(configuration["cache_dir"]+"/*/*.c")
-        print(list_of_files)
         latest_file = max(list_of_files, key=os.path.getctime)
         with open(latest_file, 'r') as file:
             generated_code = file.read()

--- a/test/unit/test_vectorisation.py
+++ b/test/unit/test_vectorisation.py
@@ -77,7 +77,7 @@ class TestVectorisation:
 
     def test_no_vectorisation(self, md1, md):
         # turn vectorisation off
-        op2.init(**{"vectorization_strategy": ""})
+        configuration.reconfigure(vectorization_strategy="")
 
         # Test that unvectorised code produced the correct result
         ret = md.inner(md1)
@@ -93,7 +93,7 @@ class TestVectorisation:
         assert not (any(key in generated_code for key in some_vectorisation_keys)), "The kernel for an inner product has not been succesfully vectorised."
 
         # change vect config back to be turned on by default
-        op2.init(**{"vectorization_strategy": "cross-element"})
+        configuration.reconfigure(vectorization_strategy="cross-element")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements automatic cross-element vectorisation (This is the work from TJ and Kaushik)

See https://github.com/firedrakeproject/firedrake/pull/2365 for `firedrake` CI runs.
The corresponding loopy PR is https://github.com/inducer/loopy/pull/557.

Big thanks to @kaushikcfd for working hard on an update of this so that we can get it merged.

**The mechanism in PyOP2**

1. Check if kernel is vectorisable (see list below)
2. Change target of the kernel to `CVectorExtensionsTarget`
3. Inline all inner kernels in the wrapper kernel
4. Align all temporaries
5. Decide which instructions cannot be vectorised with extensions (see list below)
6. Shift the bound of the loop index (iname) to vectorise over so that it starts from 0
7. Split the iname (according to the SIMD length of the architecture which is determined with py-cpuinfo)
8. Break the temporaries (add a new axis to the temporary) and index it with the provided iname
9. Tag axes to vectorise over
10. Tag iname to vectorise with with `lp.VectorizeTag(lp.OpenMPSIMDTag())` where `VectorizeTag` indicates that we try to use vector extensions first, but if an instruction can't be vectorised we use the fallback `OpenMPSIMDTag` which wraps the instruction in openmp simd pragmas

**Kernels which cannot be vectorised**

- Kernels which assemble matrices
- Kernels which use complex types
- Kernels with read write access arguments
- The kernels which generate the extrusion coordinates
- Kernels with conditionals

**Single instructions which cannot be vectorised**
- Instructions which are outside the loop which was split (because they don't depend on the loop index we vectorise over)
- Constant literal temporaries on the RHS (because we cannot just index into them)
- Instruction with calls to Slate inverses and solve (gcc could do this, Kaushik extended the solve and inverse callables in PyOP2 with strided versions for that, but clang can't)