### PR TITLE
JDBetteridge/more compilers

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -59,7 +59,6 @@ def _check_hashes(x, y, datatype):
 
 
 _check_op = MPI.Op.Create(_check_hashes, commute=True)
-global _compiler
 _compiler = None
 
 

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -266,7 +266,7 @@ class Compiler(ABC):
             compiler_flags = self.cflags
 
         # Determine cache key
-        hsh = md5(str(jitmodule.cache_key[1:]).encode())
+        hsh = md5(str(jitmodule.cache_key).encode())
         hsh.update(compiler.encode())
         if self.ld:
             hsh.update(self.ld.encode())

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -522,7 +522,7 @@ class LinuxClangCompiler(Compiler):
 
     _cflags = ("-fPIC", "-Wall", "-std=gnu11")
     _cxxflags = ("-fPIC", "-Wall")
-    _ldflags = ("-shared",)
+    _ldflags = ("-shared", "-L/usr/lib")
 
     _optflags = ("-march=native", "-O3", "-ffast-math")
     _debugflags = ("-O0", "-g")

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -656,7 +656,7 @@ class MacClangCompiler(ForkingCompiler):
     _cppflags = ["-fPIC", "-Wall", "-framework", "Accelerate"]
     _ldflags = ["-dynamiclib"]
 
-    _cflags = ["-std=c99"]
+    _cflags = ["-std=gnu11"]
     _cxxflags = []
 
     @property
@@ -679,7 +679,7 @@ class LinuxGnuCompiler(ForkingCompiler):
     _cppflags = ["-fPIC", "-Wall"]
     _ldflags = ["-shared"]
 
-    _cflags = ["-std=c99"]
+    _cflags = ["-std=gnu11"]
     _cxxflags = []
 
     _optflags = ["-march=native", "-O3", "-ffast-math"]
@@ -692,7 +692,7 @@ class LinuxIntelCompiler(ForkingCompiler):
     _cppflags = ["-fPIC", "-no-multibyte-chars"]
     _ldflags = ["-shared"]
 
-    _cflags = ["-std=c99"]
+    _cflags = ["-std=gnu11"]
     _cxxflags = []
 
     _optflags = ["-Ofast", "-xHost"]

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -89,12 +89,7 @@ def sniff_compiler_version(exe):
         try:
             ver = subprocess.check_output([exe, "-dumpversion"],
                                           stderr=subprocess.DEVNULL).decode("utf-8")
-            try:
-                ver = Version(ver.strip())
-            except ValueError:
-                # A sole digit, e.g. 7, results in a ValueError, so
-                # append a "do-nothing, but make it work" string.
-                ver = Version(ver.strip() + ".0")
+            ver = Version(ver.strip())
             if ver >= Version("7.0"):
                 try:
                     # gcc-7 series only spits out patch level on dumpfullversion.

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -32,6 +32,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+from abc import ABC, abstractmethod
 import os
 import platform
 import shutil
@@ -154,7 +155,7 @@ def compilation_comm(comm):
     return retcomm
 
 
-class Compiler(object):
+class Compiler(ABC):
 
     compiler_versions = {}
 
@@ -174,18 +175,90 @@ class Compiler(object):
     :kwarg comm: Optional communicator to compile the code on
         (defaults to COMM_WORLD).
     """
-    def __init__(self, cc, ld=None, cppargs=[], ldargs=[],
-                 cpp=False, comm=None):
-        ccenv = 'CXX' if cpp else 'CC'
+    def __init__(self, extra_cppflags=None, extra_ldflags=None, cpp=False, comm=None):
+        self._extra_cppflags = extra_cppflags or []
+        self._extra_ldflags = extra_ldflags or []
+
+        self._cpp = cpp
+        self._debug = configuration["debug"]
+
         # Ensure that this is an internal communicator.
         comm = dup_comm(comm or COMM_WORLD)
         self.comm = compilation_comm(comm)
-        self._cc = os.environ.get(ccenv, cc)
-        self._ld = os.environ.get('LDSHARED', ld)
-        self._cppargs = cppargs + configuration['cflags'].split()
-        if configuration["use_safe_cflags"]:
-            self._cppargs += self.workaround_cflags
-        self._ldargs = ldargs + configuration['ldflags'].split()
+
+    @property
+    def cc(self):
+        return os.environ.get("PYOP2_CC", self._cxx if self._cpp else self._cc)
+
+    @property
+    def ld(self):
+        return os.environ.get("PYOP2_LD", None)
+
+    @property
+    def cppflags(self):
+        try:
+            return os.environ["PYOP2_CPPFLAGS"]
+        except KeyError:
+            cppflags = self._cppflags + self._extra_cppflags
+
+            if self._debug:
+                cppflags += self._debugflags
+            else:
+                cppflags += self._optflags
+
+            if self._cpp:
+                cppflags += self._cxxflags
+            else:
+                cppflags += self._cflags
+
+            return cppflags
+
+    @property
+    def ldflags(self):
+        try:
+            return os.environ["PYOP2_LDFLAGS"]
+        except KeyError:
+            return self._ldflags + self._extra_ldflags
+
+    @property
+    def bugfix_cflags(self):
+        return []
+
+    @property
+    @abstractmethod
+    def _cc(self):
+        ...
+
+    @property
+    @abstractmethod
+    def _cxx(self):
+        ...
+
+    @property
+    @abstractmethod
+    def _optflags(self):
+        ...
+
+    @property
+    def _debugflags(self):
+        return ["-O0", "-g"]
+
+    @property
+    @abstractmethod
+    def _cppflags(self):
+        ...
+
+    @property
+    def _cflags(self):
+        return ["-std=c99"]
+
+    @property
+    def _cxxflags(self):
+        return []
+
+    @property
+    def _ldflags(self):
+        return []
 
     @property
     def compiler_version(self):
@@ -355,94 +428,82 @@ Compile errors in %s""" % (e.cmd, e.returncode, logfile, errfile))
             return ctypes.CDLL(soname)
 
 
-class MacCompiler(Compiler):
-    """A compiler for building a shared library on mac systems.
+class MacClangCompiler(Compiler):
+    """A compiler for building a shared library on mac systems."""
 
-    :arg cppargs: A list of arguments to pass to the C compiler
-         (optional).
-    :arg ldargs: A list of arguments to pass to the linker (optional).
+    @property
+    def _cc(self):
+        return "clang"
 
-    :arg cpp: Are we actually using the C++ compiler?
+    @property
+    def _cxx(self):
+        return "clang++"
 
-    :kwarg comm: Optional communicator to compile the code on (only
-        rank 0 compiles code) (defaults to COMM_WORLD).
-    """
+    @property
+    def _cppflags(self):
+        return ["-fPIC", "-Wall", "-framework", "Accelerate"]
 
-    def __init__(self, cppargs=[], ldargs=[], cpp=False, comm=None):
-        machine = platform.uname().machine
+    @property
+    def _optflags(self):
         opt_flags = ["-O3", "-ffast-math"]
         if machine == "arm64":
             # See https://stackoverflow.com/q/65966969
             opt_flags.append("-mcpu=apple-a14")
         elif machine == "x86_64":
             opt_flags.append("-march=native")
+        return opt_flags
 
-        if configuration["debug"]:
-            opt_flags = ["-O0", "-g"]
-
-        cc = "mpicc"
-        stdargs = ["-std=gnu11"]
-        if cpp:
-            cc = "mpicxx"
-            stdargs = []
-        cppargs = stdargs + ['-fPIC', '-Wall', '-framework', 'Accelerate'] + \
-            opt_flags + cppargs
-        ldargs = ['-dynamiclib'] + ldargs
-        super(MacCompiler, self).__init__(cc,
-                                          cppargs=cppargs,
-                                          ldargs=ldargs,
-                                          cpp=cpp,
-                                          comm=comm)
+    @property
+    def _ldflags(self):
+        return ["-dynamiclib"]
 
 
-class LinuxCompiler(Compiler):
-    """A compiler for building a shared library on linux systems.
+class LinuxGnuCompiler(Compiler):
+    """A compiler for building a shared library on Linux systems."""
 
-    :arg cppargs: A list of arguments to pass to the C compiler
-         (optional).
-    :arg ldargs: A list of arguments to pass to the linker (optional).
-    :arg cpp: Are we actually using the C++ compiler?
-    :kwarg comm: Optional communicator to compile the code on (only
-    rank 0 compiles code) (defaults to COMM_WORLD)."""
-    def __init__(self, cppargs=[], ldargs=[], cpp=False, comm=None):
-        opt_flags = ['-march=native', '-O3', '-ffast-math']
-        if configuration['debug']:
-            opt_flags = ['-O0', '-g']
-        cc = "mpicc"
-        stdargs = ["-std=gnu11"]
-        if cpp:
-            cc = "mpicxx"
-            stdargs = []
-        cppargs = stdargs + ['-fPIC', '-Wall'] + opt_flags + cppargs
-        ldargs = ['-shared'] + ldargs
+    @property
+    def _cc(self):
+        return "gcc"
 
-        super(LinuxCompiler, self).__init__(cc, cppargs=cppargs, ldargs=ldargs,
-                                            cpp=cpp, comm=comm)
+    @property
+    def _cxx(self):
+        return "g++"
+
+    @property
+    def _cppflags(self):
+        return ["-fPIC", "-Wall"]
+
+    @property
+    def _ldargs(self):
+        return ["-shared"]
+
+    @property
+    def _optflags(self):
+        return ["-march=native", "-O3", "-ffast-math"]
 
 
 class LinuxIntelCompiler(Compiler):
-    """The intel compiler for building a shared library on linux systems.
+    """The Intel compiler for building a shared library on Linux systems."""
 
-    :arg cppargs: A list of arguments to pass to the C compiler
-         (optional).
-    :arg ldargs: A list of arguments to pass to the linker (optional).
-    :arg cpp: Are we actually using the C++ compiler?
-    :kwarg comm: Optional communicator to compile the code on (only
-        rank 0 compiles code) (defaults to COMM_WORLD).
-    """
-    def __init__(self, cppargs=[], ldargs=[], cpp=False, comm=None):
-        opt_flags = ['-Ofast', '-xHost']
-        if configuration['debug']:
-            opt_flags = ['-O0', '-g']
-        cc = "mpicc"
-        stdargs = ["-std=gnu11"]
-        if cpp:
-            cc = "mpicxx"
-            stdargs = []
-        cppargs = stdargs + ['-fPIC', '-no-multibyte-chars'] + opt_flags + cppargs
-        ldargs = ['-shared'] + ldargs
-        super(LinuxIntelCompiler, self).__init__(cc, cppargs=cppargs, ldargs=ldargs,
-                                                 cpp=cpp, comm=comm)
+    @property
+    def _cc(self):
+        return "icc"
+
+    @property
+    def _cxx(self):
+        return "icpc"
+
+    @property
+    def _cppflags(self):
+        return ["-fPIC", "-no-multibyte-chars"]
+
+    @property
+    def _optflags(self):
+        return ["-Ofast", "-xHost"]
+
+    @property
+    def _ldflags(self):
+        return ["-shared"]
 
 
 @collective

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -494,6 +494,13 @@ class LinuxCrayCompiler(Compiler):
         return ldflags
 
 
+class AnonymousCompiler(Compiler):
+    """Compiler for building a shared library on systems with unknown compiler.
+    The properties of this compiler are entirely controlled through environment
+    variables"""
+    _name = "Unknown"
+
+
 @collective
 def load(jitmodule, extension, fn_name, cppargs=[], ldargs=[],
          argtypes=None, restype=None, comm=None):
@@ -547,15 +554,14 @@ def load(jitmodule, extension, fn_name, cppargs=[], ldargs=[],
         elif compiler_name == "Cray":
             compiler = LinuxCrayCompiler
         else:
-            raise CompilationError("Unrecognized compiler name '%s'" % compiler)
+            compiler = AnonymousCompiler
     elif sys.platform.find("darwin") == 0:
         if compiler_name == "clang":
             compiler = MacClangCompiler
         else:
-            raise CompilationError("Unrecognized compiler name '%s'" % compiler)
+            compiler = AnonymousCompiler
     else:
-        raise CompilationError("Don't know what compiler to use for platform '%s'" %
-                               sys.platform)
+        compiler = AnonymousCompiler
 
     dll = compiler(cppargs, ldargs, cpp=cpp, comm=comm, version=version).get_so(code, extension)
     fn = getattr(dll, fn_name)

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -59,6 +59,7 @@ def _check_hashes(x, y, datatype):
 
 
 _check_op = MPI.Op.Create(_check_hashes, commute=True)
+global _compiler
 _compiler = None
 
 
@@ -69,14 +70,20 @@ def set_default_compiler(compiler):
         OR a subclass of the Compiler class
     """
     global _compiler
-    if not _compiler:
-        if isinstance(compiler, str):
-            _compiler = sniff_compiler(compiler)
-        elif isinstance(compiler, Compiler):
-            _compiler = compiler
+    if _compiler:
+        warning(
+            "`set_default_compiler` should only ever be called once, calling"
+            " multiple times is untested and may produce unexpected results"
+        )
+    if isinstance(compiler, str):
+        _compiler = sniff_compiler(compiler)
+    elif isinstance(compiler, type) and issubclass(compiler, Compiler):
+        _compiler = compiler
     else:
-        warning("`set_default_compiler` should only ever be called once,"
-                "calling multiple times is untested and may produce unexpected results")
+        raise TypeError(
+            "compiler must be a path to a compiler (a string) or a subclass"
+            " of the pyop2.compilation.Compiler class"
+        )
 
 
 def sniff_compiler(exe):

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -41,7 +41,7 @@ import sys
 import ctypes
 import collections
 from hashlib import md5
-from distutils import version
+from packaging.version import Version
 
 
 from pyop2.mpi import MPI, collective, COMM_WORLD
@@ -90,17 +90,17 @@ def sniff_compiler_version(exe):
             ver = subprocess.check_output([exe, "-dumpversion"],
                                           stderr=subprocess.DEVNULL).decode("utf-8")
             try:
-                ver = version.StrictVersion(ver.strip())
+                ver = Version(ver.strip())
             except ValueError:
                 # A sole digit, e.g. 7, results in a ValueError, so
                 # append a "do-nothing, but make it work" string.
-                ver = version.StrictVersion(ver.strip() + ".0")
-            if ver >= version.StrictVersion("7.0"):
+                ver = Version(ver.strip() + ".0")
+            if ver >= Version("7.0"):
                 try:
                     # gcc-7 series only spits out patch level on dumpfullversion.
                     fullver = subprocess.check_output([exe, "-dumpfullversion"],
                                                       stderr=subprocess.DEVNULL).decode("utf-8")
-                    fullver = version.StrictVersion(fullver.strip())
+                    fullver = Version(fullver.strip())
                     ver = fullver
                 except (subprocess.CalledProcessError, UnicodeDecodeError):
                     pass
@@ -421,18 +421,18 @@ class LinuxGnuCompiler(Compiler):
         """Flags to work around bugs in compilers."""
         ver = self.version
         cflags = []
-        if version.StrictVersion("4.8.0") <= ver < version.StrictVersion("4.9.0"):
+        if Version("4.8.0") <= ver < Version("4.9.0"):
             # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61068
             cflags = ["-fno-ivopts"]
-        if version.StrictVersion("5.0") <= ver <= version.StrictVersion("5.4.0"):
+        if Version("5.0") <= ver <= Version("5.4.0"):
             cflags = ["-fno-tree-loop-vectorize"]
-        if version.StrictVersion("6.0.0") <= ver < version.StrictVersion("6.5.0"):
+        if Version("6.0.0") <= ver < Version("6.5.0"):
             # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79920
             cflags = ["-fno-tree-loop-vectorize"]
-        if version.StrictVersion("7.1.0") <= ver < version.StrictVersion("7.1.2"):
+        if Version("7.1.0") <= ver < Version("7.1.2"):
             # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81633
             cflags = ["-fno-tree-loop-vectorize"]
-        if version.StrictVersion("7.3") <= ver <= version.StrictVersion("7.5"):
+        if Version("7.3") <= ver <= Version("7.5"):
             # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90055
             # See also https://github.com/firedrakeproject/firedrake/issues/1442
             # And https://github.com/firedrakeproject/firedrake/issues/1717

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -449,6 +449,19 @@ class LinuxGnuCompiler(Compiler):
         return cflags
 
 
+class LinuxClangCompiler(Compiler):
+    """The clang for building a shared library on Linux systems."""
+
+    _ld = "ld.lld"
+
+    _cflags = ["-fPIC", "-Wall", "-std=gnu11"]
+    _cxxflags = ["-fPIC", "-Wall"]
+    _ldflags = ["-shared"]
+
+    _optflags = ["-march=native", "-O3", "-ffast-math"]
+    _debugflags = ["-O0", "-g"]
+
+
 class LinuxIntelCompiler(Compiler):
     """The Intel compiler for building a shared library on Linux systems."""
 
@@ -461,6 +474,26 @@ class LinuxIntelCompiler(Compiler):
 
     _optflags = ["-Ofast", "-xHost"]
     _debugflags = ["-O0", "-g"]
+
+
+class LinuxCrayCompiler(Compiler):
+    """The Cray compiler for building a shared library on Linux systems."""
+    _cc = "cc"
+    _cxx = "CC"
+
+    _cflags = ["-fPIC", "-Wall", "-std=gnu11"]
+    _cxxflags = ["-fPIC", "-Wall"]
+    _ldflags = ["-shared"]
+
+    _optflags = ["-march=native", "-O3", "-ffast-math"]
+    _debugflags = ["-O0", "-g"]
+
+    @property
+    def ldflags(self):
+        ldflags = super().ldflags
+        if '-llapack' in ldflags:
+            ldflags.remove('-llapack')
+        return ldflags
 
 
 @collective

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -159,252 +159,6 @@ class Compiler(ABC):
 
     compiler_versions = {}  # TODO: what to do with this?
 
-    default_cc = "mpicc"
-    default_cxx = "mpicxx"
-
-    default_cppflags = None
-    default_ldflags = None
-
-    default_cflags = None
-    default_cxxflags = None
-
-    default_optflags = None
-    default_debugflags = None
-
-    """A compiler for shared libraries.
-    :arg cc: C compiler executable (can be overriden by exporting the
-        environment variable ``CC``).
-    :arg ld: Linker executable (optional, if ``None``, we assume the compiler
-        can build object files and link in a single invocation, can be
-        overridden by exporting the environment variable ``LDSHARED``).
-    :arg cppargs: A list of arguments to the C compiler (optional, prepended to
-        any flags specified as the cflags configuration option)
-    :arg ldargs: A list of arguments to the linker (optional, prepended to any
-        flags specified as the ldflags configuration option).
-    :arg cpp: Should we try and use the C++ compiler instead of the C
-        compiler?.
-    :kwarg comm: Optional communicator to compile the code on
-        (defaults to COMM_WORLD).
-    """
-    def __init__(self, extra_cppflags=None, extra_ldflags=None, cpp=False, comm=None):
-        self._extra_cppflags = extra_cppflags or []
-        self._extra_ldflags = extra_ldflags or []
-
-        self._cpp = cpp
-        self._debug = configuration["debug"]
-
-        # Ensure that this is an internal communicator.
-        comm = dup_comm(comm or COMM_WORLD)
-        self.comm = compilation_comm(comm)
-
-    @property
-    def cc(self):
-        return os.environ.get("PYOP2_CC", self._cxx if self._cpp else self._cc)
-
-    @property
-    def ld(self):
-        return os.environ.get("PYOP2_LD", None)
-
-    @property
-    def cppflags(self):
-        try:
-            return os.environ["PYOP2_CPPFLAGS"]
-        except KeyError:
-            cppflags = self._cppflags + self._extra_cppflags
-
-            if not self._debug:
-                cppflags += self._debugflags
-            else:
-                cppflags += self._optflags
-
-            if self._cpp:
-                cppflags += self._cxxflags
-            else:
-                cppflags += self._cflags
-
-            return cppflags
-
-    @property
-    def ldflags(self):
-        try:
-            return os.environ["PYOP2_LDFLAGS"]
-        except KeyError:
-            return self._ldflags + self._extra_ldflags
-
-    @property
-    def bugfix_cflags(self):
-        return []
-
-    @property
-    def compiler_version(self):
-        key = (id(self.comm), self._cc)
-        try:
-            return Compiler.compiler_versions[key]
-        except KeyError:
-            if self.comm.rank == 0:
-                ver = sniff_compiler_version(self._cc)
-            else:
-                ver = None
-            ver = self.comm.bcast(ver, root=0)
-            return Compiler.compiler_versions.setdefault(key, ver)
-
-    @property
-    def workaround_cflags(self):
-        """Flags to work around bugs in compilers."""
-        compiler, ver = self.compiler_version
-        if compiler == "gcc":
-            if version.StrictVersion("4.8.0") <= ver < version.StrictVersion("4.9.0"):
-                # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61068
-                return ["-fno-ivopts"]
-            if version.StrictVersion("5.0") <= ver <= version.StrictVersion("5.4.0"):
-                return ["-fno-tree-loop-vectorize"]
-            if version.StrictVersion("6.0.0") <= ver < version.StrictVersion("6.5.0"):
-                # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79920
-                return ["-fno-tree-loop-vectorize"]
-            if version.StrictVersion("7.1.0") <= ver < version.StrictVersion("7.1.2"):
-                # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81633
-                return ["-fno-tree-loop-vectorize"]
-            if version.StrictVersion("7.3") <= ver <= version.StrictVersion("7.5"):
-                # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90055
-                # See also https://github.com/firedrakeproject/firedrake/issues/1442
-                # And https://github.com/firedrakeproject/firedrake/issues/1717
-                # Bug also on skylake with the vectoriser in this
-                # combination (disappears without
-                # -fno-tree-loop-vectorize!)
-                return ["-fno-tree-loop-vectorize", "-mno-avx512f"]
-        return []
-
-    @collective
-    def get_so(self, cls, jitmodule, extension):
-        """Build a shared library and load it
-        :arg jitmodule: The JIT Module which can generate the code to compile.
-        :arg extension: extension of the source file (c, cpp).
-        Returns a :class:`ctypes.CDLL` object of the resulting shared
-        library."""
-
-        # Determine cache key
-        hsh = md5(str(jitmodule.cache_key[1:]).encode())
-        hsh.update(self._cc.encode())
-        if self.ld:
-            hsh.update(self.ld.encode())
-        hsh.update("".join(self._cppargs).encode())
-        hsh.update("".join(self._ldargs).encode())
-
-        basename = hsh.hexdigest()
-
-        cachedir = configuration['cache_dir']
-
-        dirpart, basename = basename[:2], basename[2:]
-        cachedir = os.path.join(cachedir, dirpart)
-        pid = os.getpid()
-        cname = os.path.join(cachedir, "%s_p%d.%s" % (basename, pid, extension))
-        oname = os.path.join(cachedir, "%s_p%d.o" % (basename, pid))
-        soname = os.path.join(cachedir, "%s.so" % basename)
-        # Link into temporary file, then rename to shared library
-        # atomically (avoiding races).
-        tmpname = os.path.join(cachedir, "%s_p%d.so.tmp" % (basename, pid))
-
-        if configuration['check_src_hashes'] or configuration['debug']:
-            matching = self.comm.allreduce(basename, op=_check_op)
-            if matching != basename:
-                # Dump all src code to disk for debugging
-                output = os.path.join(configuration["cache_dir"], "mismatching-kernels")
-                srcfile = os.path.join(output, "src-rank%d.c" % self.comm.rank)
-                if self.comm.rank == 0:
-                    os.makedirs(output, exist_ok=True)
-                self.comm.barrier()
-                with open(srcfile, "w") as f:
-                    f.write(jitmodule.code_to_compile)
-                self.comm.barrier()
-                raise CompilationError("Generated code differs across ranks (see output in %s)" % output)
-        try:
-            # Are we in the cache?
-            return ctypes.CDLL(soname)
-        except OSError:
-            # No, let's go ahead and build
-            if self.comm.rank == 0:
-                # No need to do this on all ranks
-                os.makedirs(cachedir, exist_ok=True)
-                logfile = os.path.join(cachedir, "%s_p%d.log" % (basename, pid))
-                errfile = os.path.join(cachedir, "%s_p%d.err" % (basename, pid))
-                with progress(INFO, 'Compiling wrapper'):
-                    with open(cname, "w") as f:
-                        f.write(jitmodule.code_to_compile)
-                    # Compiler also links
-                    if self.ld is None:
-                        cc = [self._cc] + self._cppargs + \
-                             ['-o', tmpname, cname] + self._ldargs
-                        debug('Compilation command: %s', ' '.join(cc))
-                        with open(logfile, "w") as log:
-                            with open(errfile, "w") as err:
-                                log.write("Compilation command:\n")
-                                log.write(" ".join(cc))
-                                log.write("\n\n")
-                                try:
-                                    if configuration['no_fork_available']:
-                                        cc += ["2>", errfile, ">", logfile]
-                                        cmd = " ".join(cc)
-                                        status = os.system(cmd)
-                                        if status != 0:
-                                            raise subprocess.CalledProcessError(status, cmd)
-                                    else:
-                                        subprocess.check_call(cc, stderr=err,
-                                                              stdout=log)
-                                except subprocess.CalledProcessError as e:
-                                    raise CompilationError(
-                                        """Command "%s" return error status %d.
-Unable to compile code
-Compile log in %s
-Compile errors in %s""" % (e.cmd, e.returncode, logfile, errfile))
-                    else:
-                        cc = [self._cc] + self._cppargs + \
-                             ['-c', '-o', oname, cname]
-                        ld = self.ld.split() + ['-o', tmpname, oname] + self.ldargs
-                        debug('Compilation command: %s', ' '.join(cc))
-                        debug('Link command: %s', ' '.join(ld))
-                        with open(logfile, "w") as log:
-                            with open(errfile, "w") as err:
-                                log.write("Compilation command:\n")
-                                log.write(" ".join(cc))
-                                log.write("\n\n")
-                                log.write("Link command:\n")
-                                log.write(" ".join(ld))
-                                log.write("\n\n")
-                                try:
-                                    if configuration['no_fork_available']:
-                                        cc += ["2>", errfile, ">", logfile]
-                                        ld += ["2>", errfile, ">", logfile]
-                                        cccmd = " ".join(cc)
-                                        ldcmd = " ".join(ld)
-                                        status = os.system(cccmd)
-                                        if status != 0:
-                                            raise subprocess.CalledProcessError(status, cccmd)
-                                        status = os.system(ldcmd)
-                                        if status != 0:
-                                            raise subprocess.CalledProcessError(status, ldcmd)
-                                    else:
-                                        subprocess.check_call(cc, stderr=err,
-                                                              stdout=log)
-                                        subprocess.check_call(ld, stderr=err,
-                                                              stdout=log)
-                                except subprocess.CalledProcessError as e:
-                                    raise CompilationError(
-                                        """Command "%s" return error status %d.
-Unable to compile code
-Compile log in %s
-Compile errors in %s""" % (e.cmd, e.returncode, logfile, errfile))
-                    # Atomically ensure soname exists
-                    os.rename(tmpname, soname)
-            # Wait for compilation to complete
-            self.comm.barrier()
-            # Load resulting library
-            return ctypes.CDLL(soname)
-
-
-class ForkingCompiler(Compiler, ABC):
-
-    compiler_versions = {}
-
     _cc = "mpicc"
     _cxx = "mpicxx"
 
@@ -418,7 +172,6 @@ class ForkingCompiler(Compiler, ABC):
     _debugflags = None
 
     """A compiler for shared libraries.
-
     :arg cc: C compiler executable (can be overriden by exporting the
         environment variable ``CC``).
     :arg ld: Linker executable (optional, if ``None``, we assume the compiler
@@ -497,47 +250,23 @@ class ForkingCompiler(Compiler, ABC):
 
     @property
     def workaround_cflags(self):
-        """Flags to work around bugs in compilers."""
-        compiler, ver = self.compiler_version
-        if compiler == "gcc":
-            if version.StrictVersion("4.8.0") <= ver < version.StrictVersion("4.9.0"):
-                # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61068
-                return ["-fno-ivopts"]
-            if version.StrictVersion("5.0") <= ver <= version.StrictVersion("5.4.0"):
-                return ["-fno-tree-loop-vectorize"]
-            if version.StrictVersion("6.0.0") <= ver < version.StrictVersion("6.5.0"):
-                # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79920
-                return ["-fno-tree-loop-vectorize"]
-            if version.StrictVersion("7.1.0") <= ver < version.StrictVersion("7.1.2"):
-                # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81633
-                return ["-fno-tree-loop-vectorize"]
-            if version.StrictVersion("7.3") <= ver <= version.StrictVersion("7.5"):
-                # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90055
-                # See also https://github.com/firedrakeproject/firedrake/issues/1442
-                # And https://github.com/firedrakeproject/firedrake/issues/1717
-                # Bug also on skylake with the vectoriser in this
-                # combination (disappears without
-                # -fno-tree-loop-vectorize!)
-                return ["-fno-tree-loop-vectorize", "-mno-avx512f"]
         return []
 
     @collective
     def get_so(self, jitmodule, extension):
         """Build a shared library and load it
-
         :arg jitmodule: The JIT Module which can generate the code to compile.
         :arg extension: extension of the source file (c, cpp).
-
         Returns a :class:`ctypes.CDLL` object of the resulting shared
         library."""
 
         # Determine cache key
-        hsh = md5(str(jitmodule.cache_key).encode())
+        hsh = md5(str(jitmodule.cache_key[1:]).encode())
         hsh.update(self._cc.encode())
         if self.ld:
             hsh.update(self.ld.encode())
-        hsh.update("".join(self.cppflags).encode())
-        hsh.update("".join(self.ldflags).encode())
+        hsh.update("".join(self._cppflags).encode())
+        hsh.update("".join(self._ldflags).encode())
 
         basename = hsh.hexdigest()
 
@@ -581,7 +310,7 @@ class ForkingCompiler(Compiler, ABC):
                         f.write(jitmodule.code_to_compile)
                     # Compiler also links
                     if self.ld is None:
-                        cc = [self._cc] + self.cppflags + \
+                        cc = [self.cc] + self.cppflags + \
                              ['-o', tmpname, cname] + self.ldflags
                         debug('Compilation command: %s', ' '.join(cc))
                         with open(logfile, "w") as log:
@@ -606,9 +335,9 @@ Unable to compile code
 Compile log in %s
 Compile errors in %s""" % (e.cmd, e.returncode, logfile, errfile))
                     else:
-                        cc = [self._cc] + self.cppflags + \
+                        cc = [self.cc] + self.cppflags + \
                              ['-c', '-o', oname, cname]
-                        ld = self._ld.split() + ['-o', tmpname, oname] + self.ldflags
+                        ld = self.ld.split() + ['-o', tmpname, oname] + self.ldflags
                         debug('Compilation command: %s', ' '.join(cc))
                         debug('Link command: %s', ' '.join(ld))
                         with open(logfile, "w") as log:
@@ -650,7 +379,7 @@ Compile errors in %s""" % (e.cmd, e.returncode, logfile, errfile))
             return ctypes.CDLL(soname)
 
 
-class MacClangCompiler(ForkingCompiler):
+class MacClangCompiler(Compiler):
     """A compiler for building a shared library on mac systems."""
 
     _cppflags = ["-fPIC", "-Wall", "-framework", "Accelerate"]
@@ -673,7 +402,7 @@ class MacClangCompiler(ForkingCompiler):
     _debugflags = ["-O0", "-g"]
 
 
-class LinuxGnuCompiler(ForkingCompiler):
+class LinuxGnuCompiler(Compiler):
     """A compiler for building a shared library on Linux systems."""
 
     _cppflags = ["-fPIC", "-Wall"]
@@ -685,8 +414,34 @@ class LinuxGnuCompiler(ForkingCompiler):
     _optflags = ["-march=native", "-O3", "-ffast-math"]
     _debugflags = ["-O0", "-g"]
 
+    @property
+    def workaround_cflags(self):
+        """Flags to work around bugs in compilers."""
+        compiler, ver = self.compiler_version
+        cflags = []
+        if version.StrictVersion("4.8.0") <= ver < version.StrictVersion("4.9.0"):
+            # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61068
+            cflags = ["-fno-ivopts"]
+        if version.StrictVersion("5.0") <= ver <= version.StrictVersion("5.4.0"):
+            cflags = ["-fno-tree-loop-vectorize"]
+        if version.StrictVersion("6.0.0") <= ver < version.StrictVersion("6.5.0"):
+            # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79920
+            cflags = ["-fno-tree-loop-vectorize"]
+        if version.StrictVersion("7.1.0") <= ver < version.StrictVersion("7.1.2"):
+            # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81633
+            cflags = ["-fno-tree-loop-vectorize"]
+        if version.StrictVersion("7.3") <= ver <= version.StrictVersion("7.5"):
+            # GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90055
+            # See also https://github.com/firedrakeproject/firedrake/issues/1442
+            # And https://github.com/firedrakeproject/firedrake/issues/1717
+            # Bug also on skylake with the vectoriser in this
+            # combination (disappears without
+            # -fno-tree-loop-vectorize!)
+            cflags = ["-fno-tree-loop-vectorize", "-mno-avx512f"]
+        return cflags
 
-class LinuxIntelCompiler(ForkingCompiler):
+
+class LinuxIntelCompiler(Compiler):
     """The Intel compiler for building a shared library on Linux systems."""
 
     _cppflags = ["-fPIC", "-no-multibyte-chars"]
@@ -697,25 +452,6 @@ class LinuxIntelCompiler(ForkingCompiler):
 
     _optflags = ["-Ofast", "-xHost"]
     _debugflags = ["-O0", "-g"]
-
-
-class NonForkingCompiler(Compiler):
-    ...
-
-
-class DragonFFICompiler(NonForkingCompiler):
-    def compile(self, jitmodule, _):
-        try:
-            import pydffi
-        except ImportError:
-            raise ImportError("DragonFFI must be installed first")
-        ffi = pydffi.FFI()
-        ffi.compile(jitmodule.codetocompile)
-
-
-class TinyCCompiler(NonForkingCompiler):
-    def compile(self, jitmodule, _):
-        ...
 
 
 @collective

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -43,11 +43,17 @@ from pyop2.exceptions import ConfigurationError
 class Configuration(dict):
     r"""PyOP2 configuration parameters
 
-    :param compiler: compiler identifier (one of `gcc`, `icc`).
+    :param cc: C compiler (executable name eg: `gcc`
+        or path eg: `/opt/gcc/bin/gcc`).
+    :param cxx: C++ compiler (executable name eg: `g++`
+        or path eg: `/opt/gcc/bin/g++`).
+    :param ld: Linker (executable name `ld`
+        or path eg: `/opt/gcc/bin/ld`).
+    :param cflags: extra flags to be passed to the C compiler.
+    :param cxxflags: extra flags to be passed to the C++ compiler.
+    :param ldflags: extra flags to be passed to the linker.
     :param simd_width: number of doubles in SIMD instructions
         (e.g. 4 for AVX2, 8 for AVX512).
-    :param cflags: extra flags to be passed to the C compiler.
-    :param ldflags: extra flags to be passed to the linker.
     :param debug: Turn on debugging for generated code (turns off
         compiler optimisations).
     :param type_check: Should PyOP2 type-check API-calls?  (Default,

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -67,14 +67,7 @@ class Configuration(dict):
          to a node-local filesystem too.
     :param log_level: How chatty should PyOP2 be?  Valid values
         are "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL".
-    :param use_safe_cflags: Apply cflags turning off some compiler
-        optimisations that are known to be buggy on particular
-        versions? See :attr:`~.Compiler.workaround_cflags` for details.
-    :param dump_gencode: Should PyOP2 write the generated code
-         somewhere for inspection?
     :param print_cache_size: Should PyOP2 print the size of caches at
-        program exit?
-    :param print_summary: Should PyOP2 print a summary of timings at
         program exit?
     :param matnest: Should matrices on mixed maps be built as nests? (Default yes)
     :param block_sparsity: Should sparsity patterns on datasets with
@@ -103,16 +96,12 @@ class Configuration(dict):
             ("PYOP2_DEBUG", bool, False),
         "compute_kernel_flops":
             ("PYOP2_COMPUTE_KERNEL_FLOPS", bool, False),
-        "use_safe_cflags":
-            ("PYOP2_USE_SAFE_CFLAGS", bool, True),
         "type_check":
             ("PYOP2_TYPE_CHECK", bool, True),
         "check_src_hashes":
             ("PYOP2_CHECK_SRC_HASHES", bool, True),
         "log_level":
             ("PYOP2_LOG_LEVEL", (str, int), "WARNING"),
-        "dump_gencode":
-            ("PYOP2_DUMP_GENCODE", bool, False),
         "cache_dir":
             ("PYOP2_CACHE_DIR", str, cache_dir),
         "node_local_compilation":
@@ -121,8 +110,6 @@ class Configuration(dict):
             ("PYOP2_NO_FORK_AVAILABLE", bool, False),
         "print_cache_size":
             ("PYOP2_PRINT_CACHE_SIZE", bool, False),
-        "print_summary":
-            ("PYOP2_PRINT_SUMMARY", bool, False),
         "matnest":
             ("PYOP2_MATNEST", bool, True),
         "block_sparsity":

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -78,11 +78,8 @@ class Configuration(dict):
     """
     # name, env variable, type, default, write once
     DEFAULTS = {
-        "compiler": ("PYOP2_BACKEND_COMPILER", str, "gcc"),
         "simd_width": ("PYOP2_SIMD_WIDTH", int, 4),
         "debug": ("PYOP2_DEBUG", bool, False),
-        "cflags": ("PYOP2_CFLAGS", str, ""),
-        "ldflags": ("PYOP2_LDFLAGS", str, ""),
         "compute_kernel_flops": ("PYOP2_COMPUTE_KERNEL_FLOPS", bool, False),
         "use_safe_cflags": ("PYOP2_USE_SAFE_CFLAGS", bool, True),
         "type_check": ("PYOP2_TYPE_CHECK", bool, True),

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -77,24 +77,50 @@ class Configuration(dict):
         available for the resulting matrices.  (Default yes)
     """
     # name, env variable, type, default, write once
+    cache_dir = os.path.join(gettempdir(), "pyop2-cache-uid%s" % os.getuid())
     DEFAULTS = {
-        "simd_width": ("PYOP2_SIMD_WIDTH", int, 4),
-        "debug": ("PYOP2_DEBUG", bool, False),
-        "compute_kernel_flops": ("PYOP2_COMPUTE_KERNEL_FLOPS", bool, False),
-        "use_safe_cflags": ("PYOP2_USE_SAFE_CFLAGS", bool, True),
-        "type_check": ("PYOP2_TYPE_CHECK", bool, True),
-        "check_src_hashes": ("PYOP2_CHECK_SRC_HASHES", bool, True),
-        "log_level": ("PYOP2_LOG_LEVEL", (str, int), "WARNING"),
-        "dump_gencode": ("PYOP2_DUMP_GENCODE", bool, False),
-        "cache_dir": ("PYOP2_CACHE_DIR", str,
-                      os.path.join(gettempdir(),
-                                   "pyop2-cache-uid%s" % os.getuid())),
-        "node_local_compilation": ("PYOP2_NODE_LOCAL_COMPILATION", bool, True),
-        "no_fork_available": ("PYOP2_NO_FORK_AVAILABLE", bool, False),
-        "print_cache_size": ("PYOP2_PRINT_CACHE_SIZE", bool, False),
-        "print_summary": ("PYOP2_PRINT_SUMMARY", bool, False),
-        "matnest": ("PYOP2_MATNEST", bool, True),
-        "block_sparsity": ("PYOP2_BLOCK_SPARSITY", bool, True)
+        "cc":
+            ("PYOP2_CC", str, ""),
+        "cxx":
+            ("PYOP2_CXX", str, ""),
+        "ld":
+            ("PYOP2_LD", str, ""),
+        "cflags":
+            ("PYOP2_CFLAGS", str, ""),
+        "cxxflags":
+            ("PYOP2_CXXFLAGS", str, ""),
+        "ldflags":
+            ("PYOP2_LDFLAGS", str, ""),
+        "simd_width":
+            ("PYOP2_SIMD_WIDTH", int, 4),
+        "debug":
+            ("PYOP2_DEBUG", bool, False),
+        "compute_kernel_flops":
+            ("PYOP2_COMPUTE_KERNEL_FLOPS", bool, False),
+        "use_safe_cflags":
+            ("PYOP2_USE_SAFE_CFLAGS", bool, True),
+        "type_check":
+            ("PYOP2_TYPE_CHECK", bool, True),
+        "check_src_hashes":
+            ("PYOP2_CHECK_SRC_HASHES", bool, True),
+        "log_level":
+            ("PYOP2_LOG_LEVEL", (str, int), "WARNING"),
+        "dump_gencode":
+            ("PYOP2_DUMP_GENCODE", bool, False),
+        "cache_dir":
+            ("PYOP2_CACHE_DIR", str, cache_dir),
+        "node_local_compilation":
+            ("PYOP2_NODE_LOCAL_COMPILATION", bool, True),
+        "no_fork_available":
+            ("PYOP2_NO_FORK_AVAILABLE", bool, False),
+        "print_cache_size":
+            ("PYOP2_PRINT_CACHE_SIZE", bool, False),
+        "print_summary":
+            ("PYOP2_PRINT_SUMMARY", bool, False),
+        "matnest":
+            ("PYOP2_MATNEST", bool, True),
+        "block_sparsity":
+            ("PYOP2_BLOCK_SPARSITY", bool, True)
     }
     """Default values for PyOP2 configuration parameters"""
 

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -227,10 +227,6 @@ class GlobalKernel(Cached):
         kernel (as an `int`). Only makes sense for indirect extruded iteration.
     """
 
-    _cppargs = []
-    _libraries = []
-    _system_headers = []
-
     _cache = {}
 
     @classmethod
@@ -349,14 +345,17 @@ class GlobalKernel(Cached):
         :returns: A ctypes function pointer for the compiled function.
         """
         extension = "cpp" if self.local_kernel.cpp else "c"
-        cppargs = (self._cppargs
-                   + ["-I%s/include" % d for d in get_petsc_dir()]
-                   + ["-I%s" % d for d in self.local_kernel.include_dirs]
-                   + ["-I%s" % os.path.abspath(os.path.dirname(__file__))])
-        ldargs = ["-L%s/lib" % d for d in get_petsc_dir()] + \
-                 ["-Wl,-rpath,%s/lib" % d for d in get_petsc_dir()] + \
-                 ["-lpetsc", "-lm"] + self._libraries
-        ldargs += self.local_kernel.ldargs
+        cppargs = (
+            tuple("-I%s/include" % d for d in get_petsc_dir())
+            + tuple("-I%s" % d for d in self.local_kernel.include_dirs)
+            + ("-I%s" % os.path.abspath(os.path.dirname(__file__)),)
+        )
+        ldargs = (
+            tuple("-L%s/lib" % d for d in get_petsc_dir())
+            + tuple("-Wl,-rpath,%s/lib" % d for d in get_petsc_dir())
+            + ("-lpetsc", "-lm")
+            + tuple(self.local_kernel.ldargs)
+        )
 
         return compilation.load(self, extension, self.name,
                                 cppargs=cppargs,

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -362,7 +362,6 @@ class GlobalKernel(Cached):
                                 cppargs=cppargs,
                                 ldargs=ldargs,
                                 restype=ctypes.c_int,
-                                compiler=None,
                                 comm=comm)
 
     @cached_property

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -348,7 +348,6 @@ class GlobalKernel(Cached):
         :arg comm: The communicator the compilation is collective over.
         :returns: A ctypes function pointer for the compiled function.
         """
-        compiler = configuration["compiler"]
         extension = "cpp" if self.local_kernel.cpp else "c"
         cppargs = (self._cppargs
                    + ["-I%s/include" % d for d in get_petsc_dir()]
@@ -363,7 +362,7 @@ class GlobalKernel(Cached):
                                 cppargs=cppargs,
                                 ldargs=ldargs,
                                 restype=ctypes.c_int,
-                                compiler=compiler,
+                                compiler=None,
                                 comm=comm)
 
     @cached_property

--- a/test/unit/test_configuration.py
+++ b/test/unit/test_configuration.py
@@ -49,8 +49,7 @@ class TestConfigurationAPI:
         assert c['foo'] == 'bar'
 
     @pytest.mark.parametrize(('key', 'val'), [('debug', 'illegal'),
-                                              ('log_level', 1.5),
-                                              ('dump_gencode', 'illegal')])
+                                              ('log_level', 1.5)])
     def test_configuration_illegal_types(self, key, val):
         """Illegal types for configuration values should raise
         ConfigurationError."""


### PR DESCRIPTION
I want to add more compilers to PyOP2. Some of the structural changes come from [connorjward/add-non-forking-compiler](https://github.com/OP2/PyOP2/tree/connorjward/add-non-forking-compiler)

From here I want to add:
- Better support for the Intel compiler
- Clang compiler
- Cray compiler (which will supersede the hack in [JDBetteridge/isambard_fix](https://github.com/OP2/PyOP2/tree/JDBetteridge/isambard_fix)