### PR TITLE
Profile local kernels and set events on dll

### DIFF
--- a/pyop2/codegen/c/inverse.c
+++ b/pyop2/codegen/c/inverse.c
@@ -8,16 +8,56 @@ static PetscBLASInt ipiv_buffer[BUF_SIZE];
 static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
 #endif
 
+#ifndef PYOP2_INV_LOG_EVENTS
+#define PYOP2_INV_LOG_EVENTS
+static PetscLogEvent USER_EVENT_inv_memcpy;
+static PetscLogEvent USER_EVENT_inv_getrf;
+static PetscLogEvent USER_EVENT_inv_getri;
+#endif
+
+#ifndef BEGIN_LOG
+#define BEGIN_LOG
+static void beginLog(PetscLogEvent eventId){
+    #ifdef PYOP2_PROFILING_ENABLED
+    PetscLogEventBegin(eventId,0,0,0,0);
+    #endif
+}
+#endif
+
+#ifndef END_LOG
+#define END_LOG
+static void endLog(PetscLogEvent eventId){
+    #ifdef PYOP2_PROFILING_ENABLED
+    PetscLogEventEnd(eventId,0,0,0,0);
+    #endif
+}
+#endif
+
 static void inverse(PetscScalar* __restrict__ Aout, const PetscScalar* __restrict__ A, PetscBLASInt N)
 {
+    #ifdef PYOP2_PROFILING_ENABLED
+    PetscLogEventRegister("PyOP2InverseCallable_memcpy",PETSC_OBJECT_CLASSID,&USER_EVENT_inv_memcpy);
+    PetscLogEventRegister("PyOP2InverseCallable_getrf",PETSC_OBJECT_CLASSID,&USER_EVENT_inv_getrf);
+    PetscLogEventRegister("PyOP2InverseCallable_getri",PETSC_OBJECT_CLASSID,&USER_EVENT_inv_getri);
+    #endif
+
+    beginLog(USER_EVENT_inv_memcpy);
     PetscBLASInt info;
     PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));
     PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N*N*sizeof(*Awork));
     memcpy(Aout, A, N*N*sizeof(PetscScalar));
+    endLog(USER_EVENT_inv_memcpy);
+
+    beginLog(USER_EVENT_inv_getrf);
     LAPACKgetrf_(&N, &N, Aout, &N, ipiv, &info);
+    endLog(USER_EVENT_inv_getrf);
+
     if(info == 0){
+        beginLog(USER_EVENT_inv_getri);
         LAPACKgetri_(&N, Aout, &N, ipiv, Awork, &N, &info);
+        endLog(USER_EVENT_inv_getri);
     }
+
     if(info != 0){
         fprintf(stderr, "Getri throws nonzero info.");
         abort();

--- a/pyop2/codegen/c/inverse.c
+++ b/pyop2/codegen/c/inverse.c
@@ -10,52 +10,30 @@ static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
 
 #ifndef PYOP2_INV_LOG_EVENTS
 #define PYOP2_INV_LOG_EVENTS
-static PetscLogEvent USER_EVENT_inv_memcpy;
-static PetscLogEvent USER_EVENT_inv_getrf;
-static PetscLogEvent USER_EVENT_inv_getri;
+PetscLogEvent ID_inv_memcpy = -1;
+PetscLogEvent ID_inv_getrf = -1;
+PetscLogEvent ID_inv_getri = -1;
+static PetscBool log_active_inv = 0;
 #endif
 
-#ifndef BEGIN_LOG
-#define BEGIN_LOG
-static void beginLog(PetscLogEvent eventId){
-    #ifdef PYOP2_PROFILING_ENABLED
-    PetscLogEventBegin(eventId,0,0,0,0);
-    #endif
-}
-#endif
-
-#ifndef END_LOG
-#define END_LOG
-static void endLog(PetscLogEvent eventId){
-    #ifdef PYOP2_PROFILING_ENABLED
-    PetscLogEventEnd(eventId,0,0,0,0);
-    #endif
-}
-#endif
-
-static void inverse(PetscScalar* __restrict__ Aout, const PetscScalar* __restrict__ A, PetscBLASInt N)
+void inverse(PetscScalar* __restrict__ Aout, const PetscScalar* __restrict__ A, PetscBLASInt N)
 {
-    #ifdef PYOP2_PROFILING_ENABLED
-    PetscLogEventRegister("PyOP2InverseCallable_memcpy",PETSC_OBJECT_CLASSID,&USER_EVENT_inv_memcpy);
-    PetscLogEventRegister("PyOP2InverseCallable_getrf",PETSC_OBJECT_CLASSID,&USER_EVENT_inv_getrf);
-    PetscLogEventRegister("PyOP2InverseCallable_getri",PETSC_OBJECT_CLASSID,&USER_EVENT_inv_getri);
-    #endif
-
-    beginLog(USER_EVENT_inv_memcpy);
+    PetscLogIsActive(&log_active_inv);
+    if (log_active_inv){PetscLogEventBegin(ID_inv_memcpy,0,0,0,0);}
     PetscBLASInt info;
     PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));
     PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N*N*sizeof(*Awork));
     memcpy(Aout, A, N*N*sizeof(PetscScalar));
-    endLog(USER_EVENT_inv_memcpy);
+    if (log_active_inv){PetscLogEventEnd(ID_inv_memcpy,0,0,0,0);}
 
-    beginLog(USER_EVENT_inv_getrf);
+    if (log_active_inv){PetscLogEventBegin(ID_inv_getrf,0,0,0,0);}
     LAPACKgetrf_(&N, &N, Aout, &N, ipiv, &info);
-    endLog(USER_EVENT_inv_getrf);
+    if (log_active_inv){PetscLogEventEnd(ID_inv_getrf,0,0,0,0);}
 
     if(info == 0){
-        beginLog(USER_EVENT_inv_getri);
+        if (log_active_inv){PetscLogEventBegin(ID_inv_getri,0,0,0,0);}
         LAPACKgetri_(&N, Aout, &N, ipiv, Awork, &N, &info);
-        endLog(USER_EVENT_inv_getri);
+        if (log_active_inv){PetscLogEventEnd(ID_inv_getri,0,0,0,0);}
     }
 
     if(info != 0){

--- a/pyop2/codegen/c/solve.c
+++ b/pyop2/codegen/c/solve.c
@@ -8,19 +8,59 @@ static PetscBLASInt ipiv_buffer[BUF_SIZE];
 static PetscScalar work_buffer[BUF_SIZE*BUF_SIZE];
 #endif
 
+#ifndef PYOP2_SOLVE_LOG_EVENTS
+#define PYOP2_SOLVE_LOG_EVENTS
+static PetscLogEvent USER_EVENT_solve_memcpy;
+static PetscLogEvent USER_EVENT_solve_getrf;
+static PetscLogEvent USER_EVENT_solve_getrs;
+#endif
+
+#ifndef BEGIN_LOG
+#define BEGIN_LOG
+static void beginLog(PetscLogEvent eventId){
+    #ifdef PYOP2_PROFILING_ENABLED
+    PetscLogEventBegin(eventId,0,0,0,0);
+    #endif
+}
+#endif
+
+#ifndef END_LOG
+#define END_LOG
+static void endLog(PetscLogEvent eventId){
+    #ifdef PYOP2_PROFILING_ENABLED
+    PetscLogEventEnd(eventId,0,0,0,0);
+    #endif
+}
+#endif
+
 static void solve(PetscScalar* __restrict__ out, const PetscScalar* __restrict__ A, const PetscScalar* __restrict__ B, PetscBLASInt N)
 {
+    #ifdef PYOP2_PROFILING_ENABLED
+    PetscLogEventRegister("PyOP2SolveCallable_memcpy",PETSC_OBJECT_CLASSID,&USER_EVENT_solve_memcpy);
+    PetscLogEventRegister("PyOP2SolveCallable_getrf",PETSC_OBJECT_CLASSID,&USER_EVENT_solve_getrf);
+    PetscLogEventRegister("PyOP2SolveCallable_getrs",PETSC_OBJECT_CLASSID,&USER_EVENT_solve_getrs);
+    #endif
+
+    beginLog(USER_EVENT_solve_memcpy);
     PetscBLASInt info;
     PetscBLASInt *ipiv = N <= BUF_SIZE ? ipiv_buffer : malloc(N*sizeof(*ipiv));
     memcpy(out,B,N*sizeof(PetscScalar));
     PetscScalar *Awork = N <= BUF_SIZE ? work_buffer : malloc(N*N*sizeof(*Awork));
     memcpy(Awork,A,N*N*sizeof(PetscScalar));
+    endLog(USER_EVENT_solve_memcpy);
+
     PetscBLASInt NRHS = 1;
     const char T = 'T';
+    beginLog(USER_EVENT_solve_getrf);
     LAPACKgetrf_(&N, &N, Awork, &N, ipiv, &info);
+    endLog(USER_EVENT_solve_getrf);
+
     if(info == 0){
+        beginLog(USER_EVENT_solve_getrs);
         LAPACKgetrs_(&T, &N, &NRHS, Awork, &N, ipiv, out, &N, &info);
+        endLog(USER_EVENT_solve_getrs);
     }
+
     if(info != 0){
         fprintf(stderr, "Gesv throws nonzero info.");
         abort();

--- a/pyop2/codegen/loopycompat.py
+++ b/pyop2/codegen/loopycompat.py
@@ -106,7 +106,11 @@ def _match_caller_callee_argument_dimension_for_single_kernel(
 
             elif isinstance(callee_insn, (CInstruction,
                     _DataObliviousInstruction)):
-                pass
+                # The layout of the args to a CInstructions is not going to be matched to the caller_kernel,
+                # they are appended with unmatched args.
+                # We only use Cinstructions exceptionally, e.g. for adding profile instructions,
+                # without arguments that required to be matched, so this is ok.
+                new_callee_insns.append(callee_insn)
             else:
                 raise NotImplementedError("Unknown instruction %s." %
                         type(insn))

--- a/pyop2/codegen/rep2loopy.py
+++ b/pyop2/codegen/rep2loopy.py
@@ -37,6 +37,8 @@ from pytools import ImmutableRecord
 from pyop2.codegen.loopycompat import _match_caller_callee_argument_dimension_
 from pyop2.configuration import target
 
+from petsc4py import PETSc
+
 
 # Read c files  for linear algebra callables in on import
 import os
@@ -545,6 +547,8 @@ def generate(builder, wrapper_name=None):
     kernel = builder.kernel
     headers = set(kernel.headers)
     headers = headers | set(["#include <math.h>", "#include <complex.h>", "#include <petsc.h>"])
+    if PETSc.Log.isActive():
+        headers = headers | set(["#include <petsclog.h>"])
     preamble = "\n".join(sorted(headers))
 
     from coffee.base import Node

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -49,6 +49,7 @@ from pyop2.mpi import dup_comm, get_compilation_comm, set_compilation_comm
 from pyop2.configuration import configuration
 from pyop2.logger import warning, debug, progress, INFO
 from pyop2.exceptions import CompilationError
+from petsc4py import PETSc
 
 
 def _check_hashes(x, y, datatype):

--- a/pyop2/local_kernel.py
+++ b/pyop2/local_kernel.py
@@ -69,6 +69,7 @@ class LocalKernel(abc.ABC):
     :kwarg user_code: code snippet to be executed once at the very start of
         the generated kernel wrapper code (optional, defaults to
         empty)
+    :kwarg events: Tuple of log event names which are called in the C code of the local kernels
 
     Consider the case of initialising a :class:`~pyop2.Dat` with seeded random
     values in the interval 0 to 1. The corresponding :class:`~pyop2.Kernel` is
@@ -92,7 +93,8 @@ class LocalKernel(abc.ABC):
                  ldargs=(),
                  opts=None,
                  requires_zeroed_output_arguments=False,
-                 user_code=""):
+                 user_code="",
+                 events=()):
         self.code = code
         self.name = name
         self.accesses = accesses
@@ -104,6 +106,7 @@ class LocalKernel(abc.ABC):
         self.opts = opts or {}
         self.requires_zeroed_output_arguments = requires_zeroed_output_arguments
         self.user_code = user_code
+        self.events = events
 
     @property
     @abc.abstractmethod


### PR DESCRIPTION
Supercedes #646
Related to [#2388](https://github.com/firedrakeproject/firedrake/pull/2388/files) and [#273](https://github.com/firedrakeproject/tsfc/pull/273/files)

TSFC and Slate generate instructions for logging the local kernels. Both TSFC and Slate generate event names and set event ids to a default value. Now in PyOP2 we generate the actual event and link the id of it to the id in the dllwhich contains the local kernel (as replacement for the default value).


