### PR TITLE
Compilation: fix the compiler sniffing for apple.

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -107,7 +107,7 @@ def sniff_compiler(exe):
         name = "GNU"
     elif output.startswith("clang"):
         name = "clang"
-    elif output.startswith("Apple LLVM"):
+    elif output.startswith("Apple LLVM") or output.startswith("Apple clang"):
         name = "clang"
     elif output.startswith("icc"):
         name = "Intel"


### PR DESCRIPTION
I had a linker error on my (Intel) Mac. Kudos to @dham for spotting the issue.