### PR TITLE
[loopycompat.Mappers]: call super's constructor

### DIFF
--- a/pyop2/codegen/loopycompat.py
+++ b/pyop2/codegen/loopycompat.py
@@ -32,6 +32,7 @@ class DimChanger(IdentityMapper):
     def __init__(self, callee_arg_dict, desired_shape):
         self.callee_arg_dict = callee_arg_dict
         self.desired_shape = desired_shape
+        super().__init__()
 
     def map_subscript(self, expr):
         if expr.aggregate.name not in self.callee_arg_dict:
@@ -130,6 +131,7 @@ def _match_caller_callee_argument_dimension_for_single_kernel(
 class _FunctionCalledChecker(CombineMapper):
     def __init__(self, func_name):
         self.func_name = func_name
+        super().__init__()
 
     def combine(self, values):
         return any(values)


### PR DESCRIPTION
There are some potential updates to Loopy's expression traversals in https://github.com/inducer/loopy/pull/603. The downstream CI in that PR caught that we weren't calling the super-class's constructor in the PyOP2's mapper implementations. This patch should fix it.

/cc @inducer