### PR TITLE
PyOP2 compilation: add a pathway to compile with gcc on Mac.

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -139,6 +139,8 @@ def sniff_compiler(exe):
                 compiler = MacClangARMCompiler
             elif machine == "x86_64":
                 compiler = MacClangCompiler
+        elif name == "GNU":
+            compiler = MacGNUCompiler
         else:
             compiler = AnonymousCompiler
     else:
@@ -469,6 +471,11 @@ class MacClangARMCompiler(MacClangCompiler):
     # seems to be a homebrew configuration issue somewhere. Hopefully this
     # requirement will go away at some point.
     _ldflags = ("-dynamiclib", "-L/opt/homebrew/opt/gcc/lib/gcc/11")
+
+
+class MacGNUCompiler(MacClangCompiler):
+    """A compiler for building a shared library on Mac systems with a GNU compiler."""
+    _name = "Mac GNU"
 
 
 class LinuxGnuCompiler(Compiler):


### PR DESCRIPTION
I tried to compile with `PYOP2_CC=gcc-9` but the logic in `compilation.py` made me end up in the `AnonymousCompiler` which does not set any linker flags. I don't want to set these by hand so I added a `MacGNUCompiler` (which uses the the same flags as the clang compiler). (Thanks @JDBetteridge)