### PR TITLE
Don't add py-cpuinfo

### DIFF
--- a/pyop2/__init__.py
+++ b/pyop2/__init__.py
@@ -7,3 +7,8 @@ from pyop2.version import __version_info__  # noqa: just expose
 from pyop2._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+from pyop2.configuration import configuration
+from pyop2.compilation import max_simd_width
+if configuration["vectorization_strategy"]:
+    configuration["simd_width"] = max_simd_width()

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -40,25 +40,6 @@ from loopy.target.c import CWithGNULibcTarget
 from pyop2.exceptions import ConfigurationError
 
 
-def default_simd_width():
-    from cpuinfo import get_cpu_info
-    avx_to_width = {'avx': 2, 'avx1': 2, 'avx128': 2, 'avx2': 4,
-                    'avx256': 4, 'avx3': 8, 'avx512': 8}
-    longest_simd_extension = [t for t in get_cpu_info()["flags"] if t.startswith('avx')][-1]
-    if longest_simd_extension in avx_to_width.keys():
-        return avx_to_width[longest_simd_extension]
-    elif longest_simd_extension[:6] in avx_to_width.keys():
-        return avx_to_width[longest_simd_extension[:6]]
-    elif longest_simd_extension[:4] in avx_to_width.keys():
-        return avx_to_width[longest_simd_extension[:4]]
-    else:
-        raise ConfigurationError(f"The vector extension of your architecture is unknown.\
-                                   Must be one of {str(avx_to_width.keys())}.\
-                                   We advise to disable vectorisation \
-                                   with export PYOP2_VECT_STRATEGY=""."
-                                 )
-
-
 class Configuration(dict):
     r"""PyOP2 configuration parameters
 
@@ -117,7 +98,7 @@ class Configuration(dict):
         "ldflags":
             ("PYOP2_LDFLAGS", str, ""),
         "simd_width":
-            ("PYOP2_SIMD_WIDTH", int, 1),
+            ("PYOP2_SIMD_WIDTH", int, 4),
         "vectorization_strategy":
             ("PYOP2_VECT_STRATEGY", str, "cross-element"),
         "alignment":
@@ -193,7 +174,5 @@ class Configuration(dict):
 
 
 configuration = Configuration()
-if configuration["vectorization_strategy"]:
-    configuration["simd_width"] = default_simd_width()
 
 target = CWithGNULibcTarget()

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -4,7 +4,6 @@ pytest>=2.3
 flake8>=2.1.0
 pycparser>=2.10
 mpi4py>=1.3.1
-py-cpuinfo
 decorator<=4.4.2
 dataclasses
 cachetools


### PR DESCRIPTION
This is just an idea for how to avoid using the `py-cpuinfo` package.

To completely honest I'm not sure this is even necessary:
- It will only work on x86_64 architectures (this is also true of `py-cpuinfo`)
- It feels hacky
- The default of `PYOP2_SIMD_WIDTH=4` covers almost all use cases (with the exception of AVX512*)

If a user _really_ wants to change the SIMD width used within PYOP2 they should manually set `PYOP2_SIMD_WIDTH`, I don't really think we should try and sniff this value.

*My impression is that using AVX512 normally incurs a performance penalty due to the CPU having to downclock. A benchmark might convince me otherwise.