### PR TITLE
Refactor num_flops and fix for loopy kernels

### DIFF
--- a/pyop2/local_kernel.py
+++ b/pyop2/local_kernel.py
@@ -10,7 +10,6 @@ from loopy.tools import LoopyKeyBuilder
 import numpy as np
 
 from pyop2 import version
-from pyop2.configuration import configuration
 from pyop2.datatypes import ScalarType
 from pyop2.exceptions import NameTypeError
 from pyop2.types import Access
@@ -224,8 +223,6 @@ class CoffeeLocalKernel(LocalKernel):
     def num_flops(self):
         if self.flop_count is not None:
             return self.flop_count
-        elif not configuration["compute_kernel_flops"]:
-            return 0
         else:
             v = EstimateFlops()
             return v.visit(self.code)
@@ -254,8 +251,6 @@ class LoopyLocalKernel(LocalKernel):
     def num_flops(self):
         if self.flop_count is not None:
             return self.flop_count
-        elif not configuration["compute_kernel_flops"]:
-            return 0
         else:
             if isinstance(self.code, lp.TranslationUnit):
                 prog = self.code.with_entrypoints(self.name)

--- a/pyop2/local_kernel.py
+++ b/pyop2/local_kernel.py
@@ -197,6 +197,8 @@ class CStringLocalKernel(LocalKernel):
 
     @cached_property
     def num_flops(self):
+        """Set the numbers of FLOPs to 0 if not already known,
+           because there is no way to measure or estimate the FLOPS for string kernels. """
         if self.flop_count is not None:
             return self.flop_count
         else:
@@ -221,6 +223,8 @@ class CoffeeLocalKernel(LocalKernel):
 
     @cached_property
     def num_flops(self):
+        """Compute the numbers of FLOPs if not already known
+           using COFFEE's FLOP estimation algorithm."""
         if self.flop_count is not None:
             return self.flop_count
         else:
@@ -249,6 +253,8 @@ class LoopyLocalKernel(LocalKernel):
 
     @cached_property
     def num_flops(self):
+        """Compute the numbers of FLOPs if not already known
+           using Loo.py's FLOP counting algorithm."""
         if self.flop_count is not None:
             return self.flop_count
         else:
@@ -259,8 +265,8 @@ class LoopyLocalKernel(LocalKernel):
             knl = prog.default_entrypoint
             warnings = list(knl.silenced_warnings)
             warnings.extend(['insn_count_subgroups_upper_bound',
-                                'get_x_map_guessing_subgroup_size',
-                                'summing_if_branches_ops'])
+                             'get_x_map_guessing_subgroup_size',
+                             'summing_if_branches_ops'])
             knl = knl.copy(silenced_warnings=warnings)
             # for extrusion utils the layer arg must be fixed
             # because usually it would be a value which is passed in from the global kernel

--- a/pyop2/local_kernel.py
+++ b/pyop2/local_kernel.py
@@ -199,10 +199,7 @@ class CStringLocalKernel(LocalKernel):
     def num_flops(self):
         """Set the numbers of FLOPs to 0 if not already known,
            because there is no way to measure or estimate the FLOPS for string kernels. """
-        if self.flop_count is not None:
-            return self.flop_count
-        else:
-            return 0
+        return self.flop_count if self.flop_count is not None else 0
 
 
 class CoffeeLocalKernel(LocalKernel):
@@ -225,11 +222,7 @@ class CoffeeLocalKernel(LocalKernel):
     def num_flops(self):
         """Compute the numbers of FLOPs if not already known
            using COFFEE's FLOP estimation algorithm."""
-        if self.flop_count is not None:
-            return self.flop_count
-        else:
-            v = EstimateFlops()
-            return v.visit(self.code)
+        return self.flop_count if self.flop_count is not None else EstimateFlops().visit(self.code)
 
 
 class LoopyLocalKernel(LocalKernel):

--- a/pyop2/local_kernel.py
+++ b/pyop2/local_kernel.py
@@ -233,7 +233,7 @@ class LoopyLocalKernel(LocalKernel):
         or :class:`loopy.TranslationUnit`.
     """
 
-    @validate_type(("code", (lp.LoopKernel, lp.TranslationUnit), TypeError))
+    @validate_type(("code", (lp.TranslationUnit), TypeError))
     def __init__(self, code, *args, **kwargs):
         super().__init__(code, *args, **kwargs)
 

--- a/pyop2/local_kernel.py
+++ b/pyop2/local_kernel.py
@@ -261,8 +261,7 @@ class LoopyLocalKernel(LocalKernel):
                 warnings.extend(['insn_count_subgroups_upper_bound',
                                  'get_x_map_guessing_subgroup_size',
                                  'summing_if_branches_ops'])
-                knl = knl.copy(silenced_warnings=warnings,
-                               options=lp.Options(ignore_boostable_into=True))
+                knl = knl.copy(silenced_warnings=warnings)
                 # for extrusion utils the layer arg must be fixed
                 # because usually it would be a value which is passed in from the global kernel
                 # theoretically this changes the result but not the FLOP count

--- a/pyop2/local_kernel.py
+++ b/pyop2/local_kernel.py
@@ -253,6 +253,8 @@ class LoopyLocalKernel(LocalKernel):
             return self.flop_count
         else:
             if isinstance(self.code, lp.TranslationUnit):
+                # in order to silence the warnings we need to access
+                # the callable kernels in the translation
                 prog = self.code.with_entrypoints(self.name)
                 knl = prog.default_entrypoint
                 warnings = list(knl.silenced_warnings)
@@ -261,6 +263,9 @@ class LoopyLocalKernel(LocalKernel):
                                  'summing_if_branches_ops'])
                 knl = knl.copy(silenced_warnings=warnings,
                                options=lp.Options(ignore_boostable_into=True))
+                # for extrusion utils the layer arg must be fixed
+                # because usually it would be a value which is passed in from the global kernel
+                # theoretically this changes the result but not the FLOP count
                 knl = lp.fix_parameters(knl, layer=1)
                 prog = prog.with_kernel(knl)
             else:

--- a/pyop2/local_kernel.py
+++ b/pyop2/local_kernel.py
@@ -266,6 +266,7 @@ class LoopyLocalKernel(LocalKernel):
                                  'summing_if_branches_ops'])
                 knl = knl.copy(silenced_warnings=warnings,
                                options=lp.Options(ignore_boostable_into=True))
+                knl = lp.fix_parameters(knl, layer=1)
                 prog = prog.with_kernel(knl)
             else:
                 prog = self.code

--- a/pyop2/local_kernel.py
+++ b/pyop2/local_kernel.py
@@ -4,6 +4,7 @@ import hashlib
 from typing import Union
 
 import coffee
+from coffee.visitors import EstimateFlops
 import loopy as lp
 from loopy.tools import LoopyKeyBuilder
 import numpy as np
@@ -226,7 +227,7 @@ class CoffeeLocalKernel(LocalKernel):
         elif not configuration["compute_kernel_flops"]:
             return 0
         else:
-            v = coffee.visitors.EstimateFlops()
+            v = EstimateFlops()
             return v.visit(self.code)
 
 

--- a/pyop2/parloop.py
+++ b/pyop2/parloop.py
@@ -188,7 +188,8 @@ class Parloop:
         :arg part: The :class:`SetPartition` to compute over.
         """
         with self._compute_event():
-            PETSc.Log.logFlops(part.size*self.num_flops)
+            if configuration["compute_kernel_flops"]:
+                PETSc.Log.logFlops(part.size*self.num_flops)
             self.global_kernel(self.comm, part.offset, part.offset+part.size, *self.arglist)
 
     @cached_property


### PR DESCRIPTION
This a fix for the flop counting. If we turn flop counting on in Firedrake without this fix, all tests are failing see actions run on this commit https://github.com/firedrakeproject/firedrake/pull/2490/commits/fae62c404eeb5175b0acccbfb259c8487ac34564. The commit later pulls this PyOP2 branch in.
I also refactored the code a tiny bit and made `num_flops` a method of the specialized local kernels rather than the generic to avoid some of the `isinstance` special casing we had before.
The coffee flop counting is fixed now too.

There is something funny going on with layer args in the flop counting algorithm that I don't understand yet (see failing tests @ https://github.com/firedrakeproject/firedrake/runs/7272623399?check_suite_focus=true. (EDIT: I had to fix the layer arg in the loopy kernels because we usually pass a value for that in from the global kernel)

Order of merging: https://github.com/firedrakeproject/tsfc/pull/279, then this one, then https://github.com/firedrakeproject/firedrake/pull/2490