### PR TITLE
Fix Vec's state counter for MixedDat

### DIFF
--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -1015,13 +1015,12 @@ class MixedDat(AbstractDat, VecAccessMixin):
         # values
         if access is not Access.WRITE:
             offset = 0
-            array = self._vec.array
-            for d in self:
-                with d.vec_ro as v:
-                    size = v.local_size
-                    array[offset:offset+size] = v.array_r[:]
-                    offset += size
-            del array
+            with self._vec as array:
+                for d in self:
+                    with d.vec_ro as v:
+                        size = v.local_size
+                        array[offset:offset+size] = v.array_r[:]
+                        offset += size
 
         yield self._vec
         if access is not Access.READ:

--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -1021,6 +1021,8 @@ class MixedDat(AbstractDat, VecAccessMixin):
                     size = v.local_size
                     array[offset:offset+size] = v.array_r[:]
                     offset += size
+
+        self._vec.stateIncrease()
         yield self._vec
         if access is not Access.READ:
             # Reverse scatter to get the values back to their original locations

--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -1021,8 +1021,8 @@ class MixedDat(AbstractDat, VecAccessMixin):
                     size = v.local_size
                     array[offset:offset+size] = v.array_r[:]
                     offset += size
+            del array
 
-        self._vec.stateIncrease()
         yield self._vec
         if access is not Access.READ:
             # Reverse scatter to get the values back to their original locations


### PR DESCRIPTION
`MixedDat` objects don’t only rely on the PETSc Vec of the underlying `Dat` objects, they is also a Vec living on the mixed space that is made by duplicating the layout vector of the dataset attached to the `MixedDat` instance.

The data version of `MixedDat` is obtained by summing the data version of the underlying `Dat` (not unique but enough to detect that the data value changed), but we also need to update the data version of the vector in the mixed space in the `vec_context` where it is populated.

This causes a test to fail in firedrake as PETSc Vecs cache some operations (e.g. norm computations) based on the Vec's state counter which can lead to wrong numerical values.