### PR TITLE
Made a mistake in the compiler refactor + New liniting rules

### DIFF
--- a/pyop2/codegen/rep2loopy.py
+++ b/pyop2/codegen/rep2loopy.py
@@ -91,7 +91,7 @@ class PetscCallable(loopy.ScalarCallable):
 
     def generate_preambles(self, target):
         assert isinstance(target, type(target))
-        yield("00_petsc", "#include <petsc.h>")
+        yield ("00_petsc", "#include <petsc.h>")
         return
 
 

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -225,9 +225,9 @@ class Compiler(ABC):
     _optflags = ()
     _debugflags = ()
 
-    def __init__(self, extra_compiler_flags=None, extra_linker_flags=None, cpp=False, comm=None):
-        self._extra_compiler_flags = tuple(extra_compiler_flags) or ()
-        self._extra_linker_flags = tuple(extra_linker_flags) or ()
+    def __init__(self, extra_compiler_flags=(), extra_linker_flags=(), cpp=False, comm=None):
+        self._extra_compiler_flags = tuple(extra_compiler_flags)
+        self._extra_linker_flags = tuple(extra_linker_flags)
 
         self._cpp = cpp
         self._debug = configuration["debug"]

--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -221,7 +221,7 @@ class AbstractDat(DataCarrier, EmptyDataMixin, abc.ABC):
         # The np.save method appends a .npy extension to the file name
         # if the user has not supplied it. However, np.load does not,
         # so we need to handle this ourselves here.
-        if(filename[-4:] != ".npy"):
+        if filename[-4:] != ".npy":
             filename = filename + ".npy"
 
         if isinstance(self.data, tuple):

--- a/pyop2/utils.py
+++ b/pyop2/utils.py
@@ -237,7 +237,7 @@ def verify_reshape(data, dtype, shape, allow_none=False):
             a = np.asarray(data, dtype=t)
         except ValueError:
             raise DataValueError("Invalid data: cannot convert to %s!" % dtype)
-        except(TypeError):
+        except TypeError:
             raise DataTypeError("Invalid data type: %s" % dtype)
         try:
             # Destructively modify shape.  Fails if data are not


### PR DESCRIPTION
The `__init__` defaults actually cause an error!

This also fixes issues caused by new linting rules.