### PR TITLE
Add timeout to CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # strategy:
-    #   # Don't immediately kill all if one Python version fails
-    #   fail-fast: false
-    #   matrix:
-    #     python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+    strategy:
+      # Don't immediately kill all if one Python version fails
+      fail-fast: false
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     env:
       CC: mpicc
       PETSC_DIR: ${{ github.workspace }}/petsc
@@ -37,7 +37,7 @@ jobs:
       - name: Set correct Python version
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8' # ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Clone PETSc
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           xargs -l1 python -m pip install < requirements-git.txt
           python -m pip install pulp
           python -m pip install -U flake8
+          python -m pip install -U pytest-timeout
           python -m pip install .
 
       - name: Run linting
@@ -83,7 +84,7 @@ jobs:
       - name: Run tests
         shell: bash
         working-directory: PyOP2
-        run: pytest test -v --tb=native
+        run: pytest test -v --tb=native --timeout=600
 
       - name: Build documentation
         if: ${{ matrix.python-version == '3.10' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       PETSC_DIR: ${{ github.workspace }}/petsc
       PETSC_ARCH: default
       PETSC_CONFIGURE_OPTIONS: --with-debugging=1 --with-shared-libraries=1 --with-c2html=0 --with-fortran-bindings=0
+    timeout-minutes: 60
 
     steps:
       - name: Install system dependencies
@@ -84,7 +85,8 @@ jobs:
       - name: Run tests
         shell: bash
         working-directory: PyOP2
-        run: pytest test -v --tb=native --timeout=600
+        run: pytest --tb=native --timeout=600 -v test
+        timeout-minutes: 10
 
       - name: Build documentation
         if: ${{ matrix.python-version == '3.10' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      # Don't immediately kill all if one Python version fails
-      fail-fast: false
-      matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+    # strategy:
+    #   # Don't immediately kill all if one Python version fails
+    #   fail-fast: false
+    #   matrix:
+    #     python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     env:
       CC: mpicc
       PETSC_DIR: ${{ github.workspace }}/petsc
@@ -36,7 +36,7 @@ jobs:
       - name: Set correct Python version
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.8' # ${{ matrix.python-version }}
 
       - name: Clone PETSc
         uses: actions/checkout@v2
@@ -85,7 +85,7 @@ jobs:
       - name: Run tests
         shell: bash
         working-directory: PyOP2
-        run: pytest --tb=native --timeout=600 -v test
+        run: pytest --tb=native --timeout=480 --timeout-method=thread -o faulthandler_timeout=540 -v test
         timeout-minutes: 10
 
       - name: Build documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       PETSC_DIR: ${{ github.workspace }}/petsc
       PETSC_ARCH: default
       PETSC_CONFIGURE_OPTIONS: --with-debugging=1 --with-shared-libraries=1 --with-c2html=0 --with-fortran-bindings=0
+      RDMAV_FORK_SAFE: 1
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
Now we have a matrix of tests we should take steps to avoid burning CI hours when tests are hanging or we introduce severe performance regressions.