### PR TITLE
GCC 9 doesn't emit full version with `dumpfullversion`

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -245,30 +245,22 @@ class Compiler(ABC):
             the C compiler to determine the version number.
         """
         exe = self.cxx if cpp else self.cc
-        # `-dumpversion` is not sufficient to get the whole version string (for some compilers)
-        try:
-            output = subprocess.run(
-                [exe, "-dumpfullversion"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=True,
-                encoding="utf-8"
-            ).stdout
-            self.version = Version(output)
-        except (subprocess.CalledProcessError, UnicodeDecodeError, InvalidVersion):
-            # other compilers do not implement `-dumpfullversion`!
+        self.version = None
+        # `-dumpversion` is not sufficient to get the whole version string (for some compilers),
+        # but other compilers do not implement `-dumpfullversion`!
+        for dumpstring in ["-dumpfullversion", "-dumpversion"]:
             try:
-                exe = self.cxx if cpp else self.cc
                 output = subprocess.run(
-                    [exe, "-dumpversion"],
+                    [exe, dumpstring],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     check=True,
                     encoding="utf-8"
                 ).stdout
                 self.version = Version(output)
+                break
             except (subprocess.CalledProcessError, UnicodeDecodeError, InvalidVersion):
-                self.version = None
+                continue
 
     @property
     def bugfix_cflags(self):


### PR DESCRIPTION
I previously (wrongly) assumed this was an old GCC