### PR TITLE
Insert zero blocks on matrix diagonals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         working-directory: ${{ env.PETSC_DIR }}/src/binding/petsc4py
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade wheel cython numpy
+          python -m pip install --upgrade wheel 'cython<3' numpy
           python -m pip install --no-deps .
 
       - name: Checkout PyOP2


### PR DESCRIPTION
Fixes https://github.com/firedrakeproject/firedrake/issues/3066.

Basically we were failing to insert zeros in the right places when we construct the sparsity because we were inserting single zeros along the diagonal, rather than respecting the matrix block size. This was causing vector-valued assembly to crash.

This PR also pins the Cython version used by CI since petsc4py was otherwise not building.