### PR TITLE
don't die if the cache dir doesn't exist

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -659,6 +659,6 @@ def clear_cache(prompt=False):
 
     if remove:
         print(f"Removing cached libraries from {cachedir}")
-        shutil.rmtree(cachedir)
+        shutil.rmtree(cachedir, ignore_errors=True)
     else:
         print("Not removing cached libraries")


### PR DESCRIPTION
This is the proximate cause of the current failure to build the docdeps container on Firedrake.

I also think it's the right thing to do: if you asked to delete the cache dir and it doesn't exist, it is exceptionally unlikely that you will be dissatisfied with this state of affairs.