### PR TITLE
Remove __del__ method and add weakref.finalizer

### DIFF
--- a/pyop2/caching.py
+++ b/pyop2/caching.py
@@ -83,13 +83,6 @@ class ObjectCached(object):
     details).  The object on which the cache is stored should contain
     a dict in its ``_cache`` attribute.
 
-    .. warning ::
-
-       This kind of cache sets up a circular reference.  If either of
-       the objects implements ``__del__``, the Python garbage
-       collector will not be able to collect this cycle, and hence
-       the cache will never be evicted.
-
     .. warning::
 
         The derived class' :meth:`__init__` is still called if the

--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -42,7 +42,6 @@ import ctypes
 import shlex
 from hashlib import md5
 from packaging.version import Version, InvalidVersion
-import weakref
 
 
 from pyop2 import mpi
@@ -189,10 +188,8 @@ class Compiler(ABC):
         self._debug = configuration["debug"]
 
         # Compilation communicators are reference counted on the PyOP2 comm
-        self.pcomm = mpi.internal_comm(comm)
-        weakref.finalize(self, mpi.decref, self.pcomm)
-        self.comm = mpi.compilation_comm(self.pcomm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.pcomm = mpi.internal_comm(comm, self)
+        self.comm = mpi.compilation_comm(self.pcomm, self)
 
     def __repr__(self):
         return f"<{self._name} compiler, version {self.version or 'unknown'}>"

--- a/pyop2/mpi.py
+++ b/pyop2/mpi.py
@@ -42,6 +42,7 @@ import gc
 import glob
 import os
 import tempfile
+import weakref
 
 from pyop2.configuration import configuration
 from pyop2.exceptions import CompilationError
@@ -267,9 +268,7 @@ class temp_internal_comm:
     def __init__(self, comm):
         self.user_comm = comm
         self.internal_comm = internal_comm(self.user_comm)
-
-    def __del__(self):
-        decref(self.internal_comm)
+        weakref.finalize(self, decref, self.internal_comm)
 
     def __enter__(self):
         """ Returns an internal comm that will be safely decref'd

--- a/pyop2/mpi.py
+++ b/pyop2/mpi.py
@@ -267,8 +267,7 @@ class temp_internal_comm:
     """
     def __init__(self, comm):
         self.user_comm = comm
-        self.internal_comm = internal_comm(self.user_comm)
-        weakref.finalize(self, decref, self.internal_comm)
+        self.internal_comm = internal_comm(self.user_comm, self)
 
     def __enter__(self):
         """ Returns an internal comm that will be safely decref'd
@@ -282,10 +281,12 @@ class temp_internal_comm:
         pass
 
 
-def internal_comm(comm):
+def internal_comm(comm, obj):
     """ Creates an internal comm from the user comm.
     If comm is None, create an internal communicator from COMM_WORLD
     :arg comm: A communicator or None
+    :arg obj: The object which the comm is an attribute of
+    (usually `self`)
 
     :returns pyop2_comm: A PyOP2 internal communicator
     """
@@ -308,6 +309,7 @@ def internal_comm(comm):
         pyop2_comm = comm
     else:
         pyop2_comm = dup_comm(comm)
+    weakref.finalize(obj, decref, pyop2_comm)
     return pyop2_comm
 
 
@@ -444,10 +446,13 @@ def set_compilation_comm(comm, comp_comm):
 
 
 @collective
-def compilation_comm(comm):
+def compilation_comm(comm, obj):
     """Get a communicator for compilation.
 
     :arg comm: The input communicator, must be a PyOP2 comm.
+    :arg obj: The object which the comm is an attribute of
+    (usually `self`)
+
     :returns: A communicator used for compilation (may be smaller)
     """
     if not is_pyop2_comm(comm):
@@ -469,6 +474,7 @@ def compilation_comm(comm):
     else:
         comp_comm = comm
     incref(comp_comm)
+    weakref.finalize(obj, decref, comp_comm)
     return comp_comm
 
 

--- a/pyop2/mpi.py
+++ b/pyop2/mpi.py
@@ -479,6 +479,15 @@ def compilation_comm(comm, obj):
 
 
 def finalize_safe_debug():
+    ''' Return function for debug output.
+
+    When Python is finalizing the logging module may be finalized before we have
+    finished writing debug information. In this case we fall back to using the
+    Python `print` function to output debugging information.
+
+    Furthermore, we always want to see this finalization information when
+    running the CI tests.
+    '''
     if PYOP2_FINALIZED:
         if logger.level > DEBUG and not _running_on_ci:
             debug = lambda string: None

--- a/pyop2/parloop.py
+++ b/pyop2/parloop.py
@@ -3,6 +3,7 @@ import itertools
 import operator
 from dataclasses import dataclass
 from typing import Any, Optional, Tuple
+import weakref
 
 import loopy as lp
 import numpy as np
@@ -152,11 +153,8 @@ class Parloop:
         self.global_kernel = global_knl
         self.iterset = iterset
         self.comm = mpi.internal_comm(iterset.comm)
+        weakref.finalize(self, mpi.decref, self.comm)
         self.arguments, self.reduced_globals = self.prepare_reduced_globals(arguments, global_knl)
-
-    def __del__(self):
-        if hasattr(self, "comm"):
-            mpi.decref(self.comm)
 
     @property
     def local_kernel(self):

--- a/pyop2/parloop.py
+++ b/pyop2/parloop.py
@@ -3,7 +3,6 @@ import itertools
 import operator
 from dataclasses import dataclass
 from typing import Any, Optional, Tuple
-import weakref
 
 import loopy as lp
 import numpy as np
@@ -152,8 +151,7 @@ class Parloop:
 
         self.global_kernel = global_knl
         self.iterset = iterset
-        self.comm = mpi.internal_comm(iterset.comm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(iterset.comm, self)
         self.arguments, self.reduced_globals = self.prepare_reduced_globals(arguments, global_knl)
 
     @property

--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -3,7 +3,6 @@ import contextlib
 import ctypes
 import itertools
 import operator
-import weakref
 
 import loopy as lp
 import numpy as np
@@ -83,8 +82,7 @@ class AbstractDat(DataCarrier, EmptyDataMixin, abc.ABC):
         EmptyDataMixin.__init__(self, data, dtype, self._shape)
 
         self._dataset = dataset
-        self.comm = mpi.internal_comm(dataset.comm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(dataset.comm, self)
         self.halo_valid = True
         self._name = name or "dat_#x%x" % id(self)
 
@@ -821,8 +819,7 @@ class MixedDat(AbstractDat, VecAccessMixin):
         if not all(d.dtype == self._dats[0].dtype for d in self._dats):
             raise ex.DataValueError('MixedDat with different dtypes is not supported')
         # TODO: Think about different communicators on dats (c.f. MixedSet)
-        self.comm = mpi.internal_comm(self._dats[0].comm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(self._dats[0].comm, self)
 
     @property
     def dat_version(self):

--- a/pyop2/types/dataset.py
+++ b/pyop2/types/dataset.py
@@ -1,5 +1,4 @@
 import numbers
-import weakref
 
 import numpy as np
 from petsc4py import PETSc
@@ -30,8 +29,7 @@ class DataSet(caching.ObjectCached):
             return
         if isinstance(iter_set, Subset):
             raise NotImplementedError("Deriving a DataSet from a Subset is unsupported")
-        self.comm = mpi.internal_comm(iter_set.comm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(iter_set.comm, self)
         self._set = iter_set
         self._dim = utils.as_tuple(dim, numbers.Integral)
         self._cdim = np.prod(self._dim).item()
@@ -207,8 +205,7 @@ class GlobalDataSet(DataSet):
         if self._initialized:
             return
         self._global = global_
-        self.comm = mpi.internal_comm(global_.comm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(global_.comm, self)
         self._globalset = GlobalSet(comm=self.comm)
         self._name = "gdset_#x%x" % id(self)
         self._initialized = True
@@ -378,8 +375,7 @@ class MixedDataSet(DataSet):
             comm = self._process_args(arg, dims)[0][0].comm
         except AttributeError:
             comm = None
-        self.comm = mpi.internal_comm(comm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(comm, self)
         self._initialized = True
 
     @classmethod

--- a/pyop2/types/dataset.py
+++ b/pyop2/types/dataset.py
@@ -1,4 +1,5 @@
 import numbers
+import weakref
 
 import numpy as np
 from petsc4py import PETSc
@@ -30,17 +31,12 @@ class DataSet(caching.ObjectCached):
         if isinstance(iter_set, Subset):
             raise NotImplementedError("Deriving a DataSet from a Subset is unsupported")
         self.comm = mpi.internal_comm(iter_set.comm)
+        weakref.finalize(self, mpi.decref, self.comm)
         self._set = iter_set
         self._dim = utils.as_tuple(dim, numbers.Integral)
         self._cdim = np.prod(self._dim).item()
         self._name = name or "dset_#x%x" % id(self)
         self._initialized = True
-
-    def __del__(self):
-        # Cannot use hasattr here, since we define `__getattr__`
-        # This causes infinite recursion when looked up!
-        if "comm" in self.__dict__:
-            mpi.decref(self.comm)
 
     @classmethod
     def _process_args(cls, *args, **kwargs):
@@ -212,6 +208,7 @@ class GlobalDataSet(DataSet):
             return
         self._global = global_
         self.comm = mpi.internal_comm(global_.comm)
+        weakref.finalize(self, mpi.decref, self.comm)
         self._globalset = GlobalSet(comm=self.comm)
         self._name = "gdset_#x%x" % id(self)
         self._initialized = True
@@ -382,6 +379,7 @@ class MixedDataSet(DataSet):
         except AttributeError:
             comm = None
         self.comm = mpi.internal_comm(comm)
+        weakref.finalize(self, mpi.decref, self.comm)
         self._initialized = True
 
     @classmethod

--- a/pyop2/types/glob.py
+++ b/pyop2/types/glob.py
@@ -2,7 +2,6 @@ import contextlib
 import ctypes
 import operator
 import warnings
-import weakref
 
 import numpy as np
 from petsc4py import PETSc
@@ -244,8 +243,7 @@ class Global(SetFreeDataCarrier, VecAccessMixin):
             super().__init__(dim, data, dtype, name)
             if comm is None:
                 warnings.warn("PyOP2.Global has no comm, this is likely to break in parallel!")
-            self.comm = mpi.internal_comm(comm)
-            weakref.finalize(self, mpi.decref, self.comm)
+            self.comm = mpi.internal_comm(comm, self)
 
             # Object versioning setup
             petsc_counter = (comm and self.dtype == PETSc.ScalarType)

--- a/pyop2/types/glob.py
+++ b/pyop2/types/glob.py
@@ -27,10 +27,6 @@ class SetFreeDataCarrier(DataCarrier, EmptyDataMixin):
         self._buf = np.empty(self.shape, dtype=self.dtype)
         self._name = name or "%s_#x%x" % (self.__class__.__name__.lower(), id(self))
 
-    # ~ def __del__(self): # TODO !?
-        # ~ if hasattr(self, "comm"):
-            # ~ mpi.decref(self.comm)
-
     @utils.cached_property
     def _kernel_args_(self):
         return (self._data.ctypes.data, )

--- a/pyop2/types/glob.py
+++ b/pyop2/types/glob.py
@@ -2,6 +2,7 @@ import contextlib
 import ctypes
 import operator
 import warnings
+import weakref
 
 import numpy as np
 from petsc4py import PETSc
@@ -26,9 +27,9 @@ class SetFreeDataCarrier(DataCarrier, EmptyDataMixin):
         self._buf = np.empty(self.shape, dtype=self.dtype)
         self._name = name or "%s_#x%x" % (self.__class__.__name__.lower(), id(self))
 
-    def __del__(self):
-        if hasattr(self, "comm"):
-            mpi.decref(self.comm)
+    # ~ def __del__(self): # TODO !?
+        # ~ if hasattr(self, "comm"):
+            # ~ mpi.decref(self.comm)
 
     @utils.cached_property
     def _kernel_args_(self):
@@ -248,14 +249,11 @@ class Global(SetFreeDataCarrier, VecAccessMixin):
             if comm is None:
                 warnings.warn("PyOP2.Global has no comm, this is likely to break in parallel!")
             self.comm = mpi.internal_comm(comm)
+            weakref.finalize(self, mpi.decref, self.comm)
 
             # Object versioning setup
             petsc_counter = (comm and self.dtype == PETSc.ScalarType)
             VecAccessMixin.__init__(self, petsc_counter=petsc_counter)
-
-    def __del__(self):
-        if hasattr(self, "comm"):
-            mpi.decref(self.comm)
 
     def __str__(self):
         return "OP2 Global Argument: %s with dim %s and value %s" \

--- a/pyop2/types/map.py
+++ b/pyop2/types/map.py
@@ -1,7 +1,6 @@
 import itertools
 import functools
 import numbers
-import weakref
 
 import numpy as np
 
@@ -37,8 +36,7 @@ class Map:
     def __init__(self, iterset, toset, arity, values=None, name=None, offset=None, offset_quotient=None):
         self._iterset = iterset
         self._toset = toset
-        self.comm = mpi.internal_comm(toset.comm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(toset.comm, self)
         self._arity = arity
         self._values = utils.verify_reshape(values, dtypes.IntType,
                                             (iterset.total_size, arity), allow_none=True)
@@ -198,8 +196,7 @@ class PermutedMap(Map):
         if isinstance(map_, ComposedMap):
             raise NotImplementedError("PermutedMap of ComposedMap not implemented: simply permute before composing")
         self.map_ = map_
-        self.comm = mpi.internal_comm(map_.comm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(map_.comm, self)
         self.permutation = np.asarray(permutation, dtype=Map.dtype)
         assert (np.unique(permutation) == np.arange(map_.arity, dtype=Map.dtype)).all()
 
@@ -250,8 +247,7 @@ class ComposedMap(Map):
                 raise ex.MapTypeError("frommap.arity must be 1")
         self._iterset = maps_[-1].iterset
         self._toset = maps_[0].toset
-        self.comm = mpi.internal_comm(self._toset.comm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(self._toset.comm, self)
         self._arity = maps_[0].arity
         # Don't call super().__init__() to avoid calling verify_reshape()
         self._values = None
@@ -315,8 +311,7 @@ class MixedMap(Map, caching.ObjectCached):
             raise ex.MapTypeError("All maps needs to share a communicator")
         if len(comms) == 0:
             raise ex.MapTypeError("Don't know how to make communicator")
-        self.comm = mpi.internal_comm(comms[0])
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(comms[0], self)
         self._initialized = True
 
     @classmethod

--- a/pyop2/types/mat.py
+++ b/pyop2/types/mat.py
@@ -1,7 +1,6 @@
 import abc
 import ctypes
 import itertools
-import weakref
 
 import numpy as np
 from petsc4py import PETSc
@@ -69,15 +68,17 @@ class Sparsity(caching.ObjectCached):
             self._o_nnz = None
             self._nrows = None if isinstance(dsets[0], GlobalDataSet) else self._rmaps[0].toset.size
             self._ncols = None if isinstance(dsets[1], GlobalDataSet) else self._cmaps[0].toset.size
-            self.lcomm = mpi.internal_comm(dsets[0].comm if isinstance(dsets[0], GlobalDataSet) else self._rmaps[0].comm)
-            weakref.finalize(self, mpi.decref, self.lcomm)
-            self.rcomm = mpi.internal_comm(dsets[1].comm if isinstance(dsets[1], GlobalDataSet) else self._cmaps[0].comm)
-            weakref.finalize(self, mpi.decref, self.rcomm)
+            self.lcomm = mpi.internal_comm(
+                dsets[0].comm if isinstance(dsets[0], GlobalDataSet) else self._rmaps[0].comm,
+                self
+            )
+            self.rcomm = mpi.internal_comm(
+                dsets[1].comm if isinstance(dsets[1], GlobalDataSet) else self._cmaps[0].comm,
+                self
+            )
         else:
-            self.lcomm = mpi.internal_comm(self._rmaps[0].comm)
-            weakref.finalize(self, mpi.decref, self.lcomm)
-            self.rcomm = mpi.internal_comm(self._cmaps[0].comm)
-            weakref.finalize(self, mpi.decref, self.rcomm)
+            self.lcomm = mpi.internal_comm(self._rmaps[0].comm, self)
+            self.rcomm = mpi.internal_comm(self._cmaps[0].comm, self)
 
             rset, cset = self.dsets
             # All rmaps and cmaps have the same data set - just use the first.
@@ -98,8 +99,7 @@ class Sparsity(caching.ObjectCached):
 
         if self.lcomm != self.rcomm:
             raise ValueError("Haven't thought hard enough about different left and right communicators")
-        self.comm = mpi.internal_comm(self.lcomm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(self.lcomm, self)
         self._name = name or "sparsity_#x%x" % id(self)
         self.iteration_regions = iteration_regions
         # If the Sparsity is defined on MixedDataSets, we need to build each
@@ -381,13 +381,10 @@ class SparsityBlock(Sparsity):
         self._dims = tuple([tuple([parent.dims[i][j]])])
         self._blocks = [[self]]
         self.iteration_regions = parent.iteration_regions
-        self.lcomm = mpi.internal_comm(self.dsets[0].comm)
-        weakref.finalize(self, mpi.decref, self.lcomm)
-        self.rcomm = mpi.internal_comm(self.dsets[1].comm)
-        weakref.finalize(self, mpi.decref, self.rcomm)
+        self.lcomm = mpi.internal_comm(self.dsets[0].comm, self)
+        self.rcomm = mpi.internal_comm(self.dsets[1].comm, self)
         # TODO: think about lcomm != rcomm
-        self.comm = mpi.internal_comm(self.lcomm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(self.lcomm, self)
         self._initialized = True
 
     @classmethod
@@ -446,12 +443,9 @@ class AbstractMat(DataCarrier, abc.ABC):
                          ('name', str, ex.NameTypeError))
     def __init__(self, sparsity, dtype=None, name=None):
         self._sparsity = sparsity
-        self.lcomm = mpi.internal_comm(sparsity.lcomm)
-        weakref.finalize(self, mpi.decref, self.lcomm)
-        self.rcomm = mpi.internal_comm(sparsity.rcomm)
-        weakref.finalize(self, mpi.decref, self.rcomm)
-        self.comm = mpi.internal_comm(sparsity.comm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.lcomm = mpi.internal_comm(sparsity.lcomm, self)
+        self.rcomm = mpi.internal_comm(sparsity.rcomm, self)
+        self.comm = mpi.internal_comm(sparsity.comm, self)
         dtype = dtype or dtypes.ScalarType
         self._datatype = np.dtype(dtype)
         self._name = name or "mat_#x%x" % id(self)
@@ -954,8 +948,7 @@ class MatBlock(AbstractMat):
         colis = cset.local_ises[j]
         self.handle = parent.handle.getLocalSubMatrix(isrow=rowis,
                                                       iscol=colis)
-        self.comm = mpi.internal_comm(parent.comm)
-        weakref.finalize(self, mpi.decref, self.comm)
+        self.comm = mpi.internal_comm(parent.comm, self)
         self.local_to_global_maps = self.handle.getLGMap()
 
     @property

--- a/pyop2/types/mat.py
+++ b/pyop2/types/mat.py
@@ -1,6 +1,7 @@
 import abc
 import ctypes
 import itertools
+import weakref
 
 import numpy as np
 from petsc4py import PETSc
@@ -69,10 +70,14 @@ class Sparsity(caching.ObjectCached):
             self._nrows = None if isinstance(dsets[0], GlobalDataSet) else self._rmaps[0].toset.size
             self._ncols = None if isinstance(dsets[1], GlobalDataSet) else self._cmaps[0].toset.size
             self.lcomm = mpi.internal_comm(dsets[0].comm if isinstance(dsets[0], GlobalDataSet) else self._rmaps[0].comm)
+            weakref.finalize(self, mpi.decref, self.lcomm)
             self.rcomm = mpi.internal_comm(dsets[1].comm if isinstance(dsets[1], GlobalDataSet) else self._cmaps[0].comm)
+            weakref.finalize(self, mpi.decref, self.rcomm)
         else:
             self.lcomm = mpi.internal_comm(self._rmaps[0].comm)
+            weakref.finalize(self, mpi.decref, self.lcomm)
             self.rcomm = mpi.internal_comm(self._cmaps[0].comm)
+            weakref.finalize(self, mpi.decref, self.rcomm)
 
             rset, cset = self.dsets
             # All rmaps and cmaps have the same data set - just use the first.
@@ -94,6 +99,7 @@ class Sparsity(caching.ObjectCached):
         if self.lcomm != self.rcomm:
             raise ValueError("Haven't thought hard enough about different left and right communicators")
         self.comm = mpi.internal_comm(self.lcomm)
+        weakref.finalize(self, mpi.decref, self.comm)
         self._name = name or "sparsity_#x%x" % id(self)
         self.iteration_regions = iteration_regions
         # If the Sparsity is defined on MixedDataSets, we need to build each
@@ -128,14 +134,6 @@ class Sparsity(caching.ObjectCached):
                 self._o_nnz = onnz
             self._blocks = [[self]]
         self._initialized = True
-
-    def __del__(self):
-        if hasattr(self, "comm"):
-            mpi.decref(self.comm)
-        if hasattr(self, "lcomm"):
-            mpi.decref(self.lcomm)
-        if hasattr(self, "rcomm"):
-            mpi.decref(self.rcomm)
 
     _cache = {}
 
@@ -384,9 +382,12 @@ class SparsityBlock(Sparsity):
         self._blocks = [[self]]
         self.iteration_regions = parent.iteration_regions
         self.lcomm = mpi.internal_comm(self.dsets[0].comm)
+        weakref.finalize(self, mpi.decref, self.lcomm)
         self.rcomm = mpi.internal_comm(self.dsets[1].comm)
+        weakref.finalize(self, mpi.decref, self.rcomm)
         # TODO: think about lcomm != rcomm
         self.comm = mpi.internal_comm(self.lcomm)
+        weakref.finalize(self, mpi.decref, self.comm)
         self._initialized = True
 
     @classmethod
@@ -446,20 +447,15 @@ class AbstractMat(DataCarrier, abc.ABC):
     def __init__(self, sparsity, dtype=None, name=None):
         self._sparsity = sparsity
         self.lcomm = mpi.internal_comm(sparsity.lcomm)
+        weakref.finalize(self, mpi.decref, self.lcomm)
         self.rcomm = mpi.internal_comm(sparsity.rcomm)
+        weakref.finalize(self, mpi.decref, self.rcomm)
         self.comm = mpi.internal_comm(sparsity.comm)
+        weakref.finalize(self, mpi.decref, self.comm)
         dtype = dtype or dtypes.ScalarType
         self._datatype = np.dtype(dtype)
         self._name = name or "mat_#x%x" % id(self)
         self.assembly_state = Mat.ASSEMBLED
-
-    def __del__(self):
-        if hasattr(self, "comm"):
-            mpi.decref(self.comm)
-        if hasattr(self, "lcomm"):
-            mpi.decref(self.lcomm)
-        if hasattr(self, "rcomm"):
-            mpi.decref(self.rcomm)
 
     @utils.validate_in(('access', _modes, ex.ModeValueError))
     def __call__(self, access, path, lgmaps=None, unroll_map=False):
@@ -959,6 +955,7 @@ class MatBlock(AbstractMat):
         self.handle = parent.handle.getLocalSubMatrix(isrow=rowis,
                                                       iscol=colis)
         self.comm = mpi.internal_comm(parent.comm)
+        weakref.finalize(self, mpi.decref, self.comm)
         self.local_to_global_maps = self.handle.getLGMap()
 
     @property

--- a/pyop2/types/set.py
+++ b/pyop2/types/set.py
@@ -1,8 +1,8 @@
 import ctypes
-import functools
 import numbers
 
 import numpy as np
+import pytools
 
 from pyop2 import (
     caching,
@@ -538,10 +538,7 @@ class MixedSet(Set, caching.ObjectCached):
             "All components of a MixedSet must have the same number of layers."
         # TODO: do all sets need the same communicator?
         self.comm = mpi.internal_comm(
-            functools.reduce(
-                lambda a, b: a or b,
-                map(lambda s: s if s is None else s.comm, sets)
-            ),
+            pytools.single_valued(s.comm for s in sets if s is not None),
             self
         )
         self._initialized = True

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -8,3 +8,4 @@ decorator<=4.4.2
 dataclasses
 cachetools
 packaging
+pytools

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ install_requires = [
     'decorator',
     'mpi4py',
     'numpy>=1.6',
+    'pytools',
 ]
 
 version = sys.version_info[:2]

--- a/test/unit/test_caching.py
+++ b/test/unit/test_caching.py
@@ -536,8 +536,7 @@ class TestDiskCachedDecorator:
 
     def collective_key(self, *args):
         """Return a cache key suitable for use when collective over a communicator."""
-        # Explicitly `mpi.decref(self.comm)` in any test that uses this comm
-        self.comm = mpi.internal_comm(mpi.COMM_SELF)
+        self.comm = mpi.internal_comm(mpi.COMM_SELF, self)
         return self.comm, cachetools.keys.hashkey(*args)
 
     @pytest.fixture
@@ -575,7 +574,6 @@ class TestDiskCachedDecorator:
         assert obj1 == obj2 and obj1 is not obj2
         assert len(cache) == 2
         assert len(os.listdir(cachedir.name)) == 1
-        mpi.decref(self.comm)
 
     def test_decorator_disk_cache_reuses_results(self, cache, cachedir):
         decorated_func = disk_cached(cache, cachedir.name)(self.myfunc)


### PR DESCRIPTION
This PR changes the interface of `pyop2.mpi.internal_comm` to include an additional argument. This is the object to which the comm is associated, and the lifetime of which the internal comm (reference) is associated with.

Requires #712 to go in first