### PR TITLE
mat + sparsity: use dset.layout_vec.local_size for sizes

### DIFF
--- a/pyop2/sparsity.pyx
+++ b/pyop2/sparsity.pyx
@@ -128,13 +128,13 @@ def build_sparsity(sparsity):
     preallocator.setType(PETSc.Mat.Type.PREALLOCATOR)
     if mixed:
         # Sparsity is the dof sparsity.
-        nrows = sum(s.size*s.cdim for s in rset)
-        ncols = sum(s.size*s.cdim for s in cset)
+        nrows = rset.layout_vec.local_size
+        ncols = cset.layout_vec.local_size
         preallocator.setLGMap(rmap=rset.unblocked_lgmap, cmap=cset.unblocked_lgmap)
     else:
         # Sparsity is the block sparsity
-        nrows = rset.size
-        ncols = cset.size
+        nrows = rset.layout_vec.local_size // rset.layout_vec.block_size
+        ncols = cset.layout_vec.local_size // cset.layout_vec.block_size
         preallocator.setLGMap(rmap=rset.scalar_lgmap, cmap=cset.scalar_lgmap)
 
     preallocator.setSizes(size=((nrows, None), (ncols, None)),

--- a/pyop2/types/dataset.py
+++ b/pyop2/types/dataset.py
@@ -156,11 +156,11 @@ class DataSet(caching.ObjectCached):
         ises = []
         nlocal_rows = 0
         for dset in self:
-            nlocal_rows += dset.size * dset.cdim
+            nlocal_rows += dset.layout_vec.local_size
         offset = self.comm.scan(nlocal_rows)
         offset -= nlocal_rows
         for dset in self:
-            nrows = dset.size * dset.cdim
+            nrows = dset.layout_vec.local_size
             iset = PETSc.IS().createStride(nrows, first=offset, step=1,
                                            comm=self.comm)
             iset.setBlockSize(dset.cdim)
@@ -283,27 +283,6 @@ class GlobalDataSet(DataSet):
             lgmap = PETSc.LGMap().create(indices=indices,
                                          bsize=1, comm=self.lgmap.comm)
             return lgmap
-
-    @utils.cached_property
-    def field_ises(self):
-        """A list of PETSc ISes defining the global indices for each set in
-        the DataSet.
-
-        Used when extracting blocks from matrices for solvers."""
-        ises = []
-        nlocal_rows = 0
-        for dset in self:
-            nlocal_rows += dset.size * dset.cdim
-        offset = self.comm.scan(nlocal_rows)
-        offset -= nlocal_rows
-        for dset in self:
-            nrows = dset.size * dset.cdim
-            iset = PETSc.IS().createStride(nrows, first=offset, step=1,
-                                           comm=self.comm)
-            iset.setBlockSize(dset.cdim)
-            ises.append(iset)
-            offset += nrows
-        return tuple(ises)
 
     @utils.cached_property
     def local_ises(self):

--- a/test/unit/test_matrices.py
+++ b/test/unit/test_matrices.py
@@ -582,7 +582,7 @@ class TestMatrices:
     def test_mat_set_diagonal(self, nodes, elem_node, n):
         "Set the diagonal of the entire matrix to 1.0"
         mat = op2.Mat(op2.Sparsity(nodes**n, elem_node), valuetype)
-        nrows = mat.sparsity.nrows
+        nrows = mat.nblock_rows
         mat.set_local_diagonal_entries(list(range(nrows)))
         mat.assemble()
         assert (mat.values == np.identity(nrows * n)).all()
@@ -591,7 +591,7 @@ class TestMatrices:
     def test_mat_repeated_set_diagonal(self, nodes, elem_node, n):
         "Set the diagonal of the entire matrix to 1.0"
         mat = op2.Mat(op2.Sparsity(nodes**n, elem_node), valuetype)
-        nrows = mat.sparsity.nrows
+        nrows = mat.nblock_rows
         mat.set_local_diagonal_entries(list(range(nrows)))
         mat.assemble()
         assert (mat.values == np.identity(nrows * n)).all()


### PR DESCRIPTION
Make `Mat` and `Sparsity` inherit sizes from `dset.layout_vec`.

Firedrake test: https://github.com/firedrakeproject/firedrake/pull/3311