### PR TITLE
Only delete compcomm on icomm if it exists

### DIFF
--- a/pyop2/mpi.py
+++ b/pyop2/mpi.py
@@ -201,7 +201,7 @@ def delcomm_outer(comm, keyval, icomm):
     if comp_comm is not None:
         debug('Removing compilation comm on inner comm')
         decref(comp_comm)
-    icomm.Delete_attr(compilationcomm_keyval)
+        icomm.Delete_attr(compilationcomm_keyval)
 
     # Once we have removed the reference to the inner/compilation comm we can free it
     cidx = icomm.Get_attr(cidx_keyval)


### PR DESCRIPTION
Within the MPI implementation, an inner communicator can optionally contain a compilation commucator. An indentation error meant that the compilation attribute was unconditionally deleted, causing incorrect MPI behaviour if the attribute had never been set in the first place. On MPICH, this doesn't seem to raise any errors, but with OpenMPI it causes errors like:

    mpi4py.MPI.Exception: MPI_ERR_OTHER: known error not in list