### PR TITLE
RestrictedFunctionSpace: Added in changes to Dataset / Set for use in RestrictedFunctionSpace in firedrake

### DIFF
--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -293,7 +293,8 @@ class GlobalKernel(Cached):
                  constant_layers=False,
                  subset=False,
                  iteration_region=None,
-                 pass_layer_arg=False):
+                 pass_layer_arg=False,
+                 form_signature=None):
         if self._initialized:
             return
 
@@ -328,6 +329,7 @@ class GlobalKernel(Cached):
         self._subset = subset
         self._iteration_region = iteration_region
         self._pass_layer_arg = pass_layer_arg
+        self._form_signature = form_signature
 
         # Cache for stashing the compiled code
         self._func_cache = {}

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -293,8 +293,7 @@ class GlobalKernel(Cached):
                  constant_layers=False,
                  subset=False,
                  iteration_region=None,
-                 pass_layer_arg=False,
-                 signature=None):
+                 pass_layer_arg=False):
         if self._initialized:
             return
 
@@ -329,7 +328,6 @@ class GlobalKernel(Cached):
         self._subset = subset
         self._iteration_region = iteration_region
         self._pass_layer_arg = pass_layer_arg
-        self.signature = signature
 
         # Cache for stashing the compiled code
         self._func_cache = {}

--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -294,7 +294,7 @@ class GlobalKernel(Cached):
                  subset=False,
                  iteration_region=None,
                  pass_layer_arg=False,
-                 form_signature=None):
+                 signature=None):
         if self._initialized:
             return
 
@@ -329,7 +329,7 @@ class GlobalKernel(Cached):
         self._subset = subset
         self._iteration_region = iteration_region
         self._pass_layer_arg = pass_layer_arg
-        self._form_signature = form_signature
+        self.signature = signature
 
         # Cache for stashing the compiled code
         self._func_cache = {}

--- a/pyop2/types/dataset.py
+++ b/pyop2/types/dataset.py
@@ -113,12 +113,8 @@ class DataSet(caching.ObjectCached):
         indices for this :class:`DataSet`.
         """
         lgmap = PETSc.LGMap()
-        if self.comm.size == 1:
-            lgmap.create(indices=np.arange(self.size, dtype=dtypes.IntType),
-                         bsize=self.cdim, comm=self.comm)
-        else:
-            lgmap.create(indices=self.halo.local_to_global_numbering,
-                         bsize=self.cdim, comm=self.comm)
+        lgmap.create(indices=self.halo.local_to_global_numbering,
+                     bsize=self.cdim, comm=self.comm)
         return lgmap
 
     @utils.cached_property

--- a/pyop2/types/dataset.py
+++ b/pyop2/types/dataset.py
@@ -179,7 +179,7 @@ class DataSet(caching.ObjectCached):
     def layout_vec(self):
         """A PETSc Vec compatible with the dof layout of this DataSet."""
         vec = PETSc.Vec().create(comm=self.comm)
-        size = (self.size * self.cdim, None)
+        size = (self.size * self.cdim - self.set.constrained_size, None)
         vec.setSizes(size, bsize=self.cdim)
         vec.setUp()
         return vec

--- a/pyop2/types/dataset.py
+++ b/pyop2/types/dataset.py
@@ -183,7 +183,7 @@ class DataSet(caching.ObjectCached):
     def layout_vec(self):
         """A PETSc Vec compatible with the dof layout of this DataSet."""
         vec = PETSc.Vec().create(comm=self.comm)
-        size = ((self.size - self.set.constrained_size) * self.cdim , None)
+        size = ((self.size - self.set.constrained_size) * self.cdim, None)
         vec.setSizes(size, bsize=self.cdim)
         vec.setUp()
         return vec

--- a/pyop2/types/dataset.py
+++ b/pyop2/types/dataset.py
@@ -183,7 +183,7 @@ class DataSet(caching.ObjectCached):
     def layout_vec(self):
         """A PETSc Vec compatible with the dof layout of this DataSet."""
         vec = PETSc.Vec().create(comm=self.comm)
-        size = (self.size * self.cdim - self.set.constrained_size, None)
+        size = ((self.size - self.set.constrained_size) * self.cdim , None)
         vec.setSizes(size, bsize=self.cdim)
         vec.setUp()
         return vec
@@ -449,8 +449,8 @@ class MixedDataSet(DataSet):
         indices for this :class:`MixedDataSet`.
         """
         lgmap = PETSc.LGMap()
-        if self.comm.size == 1:
-            size = sum(s.size * s.cdim for s in self)
+        if self.comm.size == 1 and self.halo is None:
+            size = sum((s.size - s.constrained_size) * s.cdim for s in self)
             lgmap.create(indices=np.arange(size, dtype=dtypes.IntType),
                          bsize=1, comm=self.comm)
             return lgmap
@@ -479,7 +479,7 @@ class MixedDataSet(DataSet):
         # current field offset.
         idx_size = sum(s.total_size*s.cdim for s in self)
         indices = np.full(idx_size, -1, dtype=dtypes.IntType)
-        owned_sz = np.array([sum(s.size * s.cdim for s in self)],
+        owned_sz = np.array([sum((s.size - s.constrained_size) * s.cdim for s in self)],
                             dtype=dtypes.IntType)
         field_offset = np.empty_like(owned_sz)
         self.comm.Scan(owned_sz, field_offset)
@@ -493,7 +493,7 @@ class MixedDataSet(DataSet):
         current_offsets = np.zeros(self.comm.size + 1, dtype=dtypes.IntType)
         for s in self:
             idx = indices[start:start + s.total_size * s.cdim]
-            owned_sz[0] = s.size * s.cdim
+            owned_sz[0] = (s.size - s.set.constrained_size) * s.cdim
             self.comm.Scan(owned_sz, field_offset)
             self.comm.Allgather(field_offset, current_offsets[1:])
             # Find the ranks each entry in the l2g belongs to

--- a/pyop2/types/dataset.py
+++ b/pyop2/types/dataset.py
@@ -113,8 +113,12 @@ class DataSet(caching.ObjectCached):
         indices for this :class:`DataSet`.
         """
         lgmap = PETSc.LGMap()
-        lgmap.create(indices=self.halo.local_to_global_numbering,
-                     bsize=self.cdim, comm=self.comm)
+        if self.comm.size == 1 and self.halo is None:
+            lgmap.create(indices=np.arange(self.size, dtype=dtypes.IntType),
+                         bsize=self.cdim, comm=self.comm)
+        else:
+            lgmap.create(indices=self.halo.local_to_global_numbering,
+                         bsize=self.cdim, comm=self.comm)
         return lgmap
 
     @utils.cached_property

--- a/pyop2/types/set.py
+++ b/pyop2/types/set.py
@@ -64,7 +64,7 @@ class Set:
 
     @utils.validate_type(('size', (numbers.Integral, tuple, list, np.ndarray), ex.SizeTypeError),
                          ('name', str, ex.NameTypeError))
-    def __init__(self, size, name=None, halo=None, comm=None, constrained_nodes=0):
+    def __init__(self, size, name=None, halo=None, comm=None, constrained_size=0):
         self.comm = mpi.internal_comm(comm, self)
         if isinstance(size, numbers.Integral):
             size = [size] * 3
@@ -75,7 +75,7 @@ class Set:
         self._name = name or "set_#x%x" % id(self)
         self._halo = halo
         self._partition_size = 1024
-        self._constrained_size = constrained_nodes
+        self._constrained_size = constrained_size
 
         # A cache of objects built on top of this set
         self._cache = {}

--- a/pyop2/types/set.py
+++ b/pyop2/types/set.py
@@ -596,7 +596,7 @@ class MixedSet(Set, caching.ObjectCached):
 
     @utils.cached_property
     def constrained_size(self):
-        """Set size, owned elements."""
+        """Set size, owned constrained elements."""
         return sum(s.constrained_size for s in self._sets)
 
     @utils.cached_property

--- a/pyop2/types/set.py
+++ b/pyop2/types/set.py
@@ -595,6 +595,11 @@ class MixedSet(Set, caching.ObjectCached):
         return sum(s.core_size for s in self._sets)
 
     @utils.cached_property
+    def constrained_size(self):
+        """Set size, owned elements."""
+        return sum(s.constrained_size for s in self._sets)
+
+    @utils.cached_property
     def size(self):
         """Set size, owned elements."""
         return sum(0 if s is None else s.size for s in self._sets)

--- a/pyop2/types/set.py
+++ b/pyop2/types/set.py
@@ -64,7 +64,7 @@ class Set:
 
     @utils.validate_type(('size', (numbers.Integral, tuple, list, np.ndarray), ex.SizeTypeError),
                          ('name', str, ex.NameTypeError))
-    def __init__(self, size, name=None, halo=None, comm=None):
+    def __init__(self, size, name=None, halo=None, comm=None, constrained_nodes=0):
         self.comm = mpi.internal_comm(comm, self)
         if isinstance(size, numbers.Integral):
             size = [size] * 3
@@ -75,6 +75,8 @@ class Set:
         self._name = name or "set_#x%x" % id(self)
         self._halo = halo
         self._partition_size = 1024
+        self._constrained_size = constrained_nodes
+
         # A cache of objects built on top of this set
         self._cache = {}
 
@@ -87,6 +89,10 @@ class Set:
     def core_size(self):
         """Core set size.  Owned elements not touching halo elements."""
         return self._sizes[Set._CORE_SIZE]
+
+    @utils.cached_property
+    def constrained_size(self):
+        return self._constrained_size
 
     @utils.cached_property
     def size(self):


### PR DESCRIPTION
Is a part of the following pull request: [https://github.com/firedrakeproject/firedrake/pull/3426](url)

This gives sets an additional size, called constrained size. This is then used to create the correct layout_vec for restricted spaces.
There's also some signature data being passed through the global kernel as well to distinguish between restricted and unrestricted spaces.